### PR TITLE
Fix type declarations and imports for `log tail`

### DIFF
--- a/src/commands/env/log/tail.ts
+++ b/src/commands/env/log/tail.ts
@@ -3,13 +3,19 @@ import {flags} from '@oclif/command'
 import Command from '../../../lib/base'
 import axios from 'axios'
 import {cli} from 'cli-ux'
-import * as stream from 'stream'
+import * as Stream from 'stream'
 import * as url from 'url'
 import * as util from 'util'
+import EventSource = require('@heroku/eventsource')
+
+type EventSourceError = Error & ({
+  status?: number;
+  message?: string;
+})
 
 // this splits a stream into lines
 function lineTransform() {
-  const transform = new stream.Transform({objectMode: true, decodeStrings: false})
+  const transform = new Stream.Transform({objectMode: true, decodeStrings: false})
   let _lastLineData: string
 
   transform._transform = function (chunk, _encoding, next) {
@@ -32,20 +38,7 @@ function lineTransform() {
   return transform
 }
 
-import * as Stream from 'stream'
-const EventSource = require('@heroku/eventsource')
-
-type EventSource = {
-  addEventListener(event: string, callback: (x: any) => void): void;
-  close(): void;
-}
-
-type EventSourceError = Error & ({
-  status?: number;
-  message?: string;
-})
-
-function eventSourceStream(url: string, eventSourceOptions: any, tail?: boolean): Stream.Readable {
+function eventSourceStream(url: string, eventSourceOptions: EventSourceOptions, tail?: boolean): Stream.Readable {
   let eventSource: EventSource
 
   const stream = new Stream.Readable({

--- a/src/types/eventsource.d.ts
+++ b/src/types/eventsource.d.ts
@@ -1,0 +1,16 @@
+// https://developer.mozilla.org/en-US/docs/Web/API/EventSource/EventSource#parameters
+declare interface EventSourceOptions {
+  withCredentials?: boolean;
+}
+
+declare module '@heroku/eventsource' {
+  class EventSource {
+    constructor(url: string, eventSourceOptions: EventSourceOptions);
+
+    addEventListener(event: string, callback: (x: any) => void): void;
+
+    close(): void;
+  }
+
+  export = EventSource
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,9 +6,12 @@
     "outDir": "lib",
     "rootDir": "src",
     "strict": true,
-    "target": "es2017"
+    "target": "es2017",
   },
   "include": [
-    "src/**/*"
-  ]
+    "src/**/*",
+  ],
+  "ts-node": {
+    "files": true
+  }
 }


### PR DESCRIPTION
Typescript was being weird about the `@heroku/eventsource` types so this PR adds a module declaration that gives some basic type definitions for the things we use from it.