### PR TITLE
Make `env:list --all` work outside of projects

### DIFF
--- a/src/commands/env/list.ts
+++ b/src/commands/env/list.ts
@@ -220,13 +220,13 @@ export default class EnvList extends Command {
 
   async run() {
     const {flags} = this.parse(EnvList)
-    const project = await this.fetchSfdxProject()
     const {nonScratchOrgs, scratchOrgs} = await this.resolveOrgs(flags.all)
     const orgs = [...nonScratchOrgs, ...scratchOrgs]
     let environments = await this.resolveEnvironments(orgs)
     const types = flags['environment-type'] as Array<EnvironmentType> ?? ['org', 'scratchorg', 'compute']
 
     if (!flags.all) {
+      const project = await this.fetchSfdxProject()
       this.log(`Current environments for project ${project.name}\n`)
 
       if (types.includes('compute')) {


### PR DESCRIPTION
The default behavior for `env:list` is to only list environments relevant to the current project. The `--all` flag, however, indicates that they instead want to see *all* environments, regardless of relevance. Consequently, this also means that they should be able to run `env:list --all` outside of a project since the project itself is irrelevant in that case.