### PR TITLE
guard against hyphens in project names

### DIFF
--- a/src/commands/generate/project.ts
+++ b/src/commands/generate/project.ts
@@ -24,6 +24,11 @@ export default class GenerateProject extends Command {
 
   async run() {
     const {flags} = this.parse(GenerateProject)
+
+    if (flags.name.includes('-')) {
+      this.error('Project names may not include hyphens, please either remove them or use underscores.')
+    }
+
     const projectPath = path.resolve(`./${flags.name}`)
 
     if (await fs.pathExists(projectPath)) {

--- a/test/commands/generate/project.test.ts
+++ b/test/commands/generate/project.test.ts
@@ -97,4 +97,16 @@ describe('sf generate project', () => {
     expect(error.message).to.include('Directory foo already exists.')
   })
   .it('should not create duplicate project in the directory where command is executed')
+
+  test
+  .stdout()
+  .stderr()
+  .finally(() => {
+    fs.removeSync('foo')
+  })
+  .command(['generate:project', '--name=foo-bar'])
+  .catch(error => {
+    expect(error.message).to.include('Project names may not include hyphens')
+  })
+  .it('should not create a project if the name contains hyphens')
 })


### PR DESCRIPTION
Closes https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000KQPmYAO/view

Project can't have dashes in the name, so we shouldn't let them create projects with dashes in the name :P