### PR TITLE
move Functions scratch def feature to project generator

### DIFF
--- a/src/commands/generate/function.ts
+++ b/src/commands/generate/function.ts
@@ -200,6 +200,7 @@ export default class GenerateFunction extends Command {
 
   async run() {
     const {flags} = this.parse(GenerateFunction)
+    let isFirstFunction = false
 
     // Determine if we're in an SFDX project and return the path to sfdx-project.json
     let sfdxProjectPath
@@ -223,6 +224,7 @@ export default class GenerateFunction extends Command {
     const scratchDef = await readJSON(scratchDefPath)
     // Add 'Functions' feature to the project scratch org definition if it doesn't already exist
     if (!scratchDef.features.includes('Functions')) {
+      isFirstFunction = true
       scratchDef.features = [...scratchDef.features, 'Functions']
       await writeJSON(scratchDefPath, scratchDef)
     }
@@ -241,5 +243,14 @@ export default class GenerateFunction extends Command {
     template.write({fnDir: fnDir, fnName: fnName, fnNameCased: fnNameCased, isFunctionBundle: isFunctionBundle})
 
     this.log(`Created ${language} function ${herokuColor.green(fnName)} in ${herokuColor.green(fnDir)}.`)
+    if (isFirstFunction) {
+      this.log('')
+      this.log(
+        'You have just created your first Salesforce Functions module in this project!\n' +
+        'Before creating Scratch Orgs for development, please ensure that:\n' +
+        '1. Functions is enabled in your DevHub org\n' +
+        `2. ${herokuColor.green('"Functions"')} is added to your scratch org definition file ${herokuColor.green('"features"')} list`,
+      )
+    }
   }
 }


### PR DESCRIPTION
In https://github.com/heroku/sf-plugin-functions/pull/16 we added new functionality to the function generator that would update a project's `project-scratch-def.json` to add `Functions` to its list of features whenever a function was generated in a project for the first time.

The `Functions` feature is required so that scratch orgs created for the given project will be created with functions enabled, however, because we realized that not all people using `generate:project` would also be using functions, we put this functionality in the `generate:function` command as a way to guarantee that we wouldn't be giving people scratch orgs with features they didn't need (since we'd never add the `Functions` feature if they never generated a function).

However, there is one glaring problem with this: It also means that functions users who generate scratch orgs *before* actually running the function generator will also end up with scratch orgs that don't work with functions, and which will just fail inexplicably when used in concert with a compute environment. Seeing as this a massive footgun, we figure it's actually just better to give everyone the Functions feature even if some folks won't use it.