### PR TITLE
show help text on initial function generation

### DIFF
--- a/src/lib/path-utils.ts
+++ b/src/lib/path-utils.ts
@@ -34,7 +34,7 @@ export async function resolveFunctionsDirectory() {
     return fnPath
   }
 
-  throw new Error('No functions directory found')
+  throw new Error('No functions directory found.')
 }
 
 export async function resolveFunctionsPaths() {


### PR DESCRIPTION
Closes https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000Kx6OYAS/view

This PR updates the function generator to show a help introductory message when the user generates their first function in a given project. This message instructs them on how to correctly create Scratch Orgs for use with Functions. We're moving to this approach because we realized that we can't reliably automate adding the functions feature for them given that they still need to enable DevHub themselves and can use any scratch org definition file they want.