### PR TITLE
use app id instead of name for alias

### DIFF
--- a/src/commands/env/create/compute.ts
+++ b/src/commands/env/create/compute.ts
@@ -63,7 +63,7 @@ export default class EnvCreateCompute extends Command {
       if (alias) {
         const aliases = await Aliases.create({})
 
-        aliases.set(alias, app.name!)
+        aliases.set(alias, app.id!)
 
         await aliases.write()
       }

--- a/test/commands/env/create/compute.test.ts
+++ b/test/commands/env/create/compute.test.ts
@@ -99,7 +99,7 @@ describe('sf env create compute', () => {
     expect(ctx.stdout).to.contain(`New compute environment created with ID ${APP_MOCK.name}`)
     expect(ctx.stdout).to.contain(`Your compute environment with local alias ${ENVIRONMENT_ALIAS} is ready`)
     expect(orgStub).to.have.been.calledWith({aliasOrUsername: ORG_ALIAS})
-    expect(aliasSetSpy).to.have.been.calledWith(ENVIRONMENT_ALIAS, APP_MOCK.name)
+    expect(aliasSetSpy).to.have.been.calledWith(ENVIRONMENT_ALIAS, APP_MOCK.id)
     expect(aliasWriteSpy).to.have.been.called
   })
 


### PR DESCRIPTION
Closes https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000L1onYAC/view

App IDs are immutable, app name can be squatted. Users can still pass app name if they want, but if we're going to actually store something long-term, we should use the ID instead.