### PR TITLE
add guard in generate:function for function name rules

### DIFF
--- a/src/commands/generate/function.ts
+++ b/src/commands/generate/function.ts
@@ -249,14 +249,17 @@ export default class GenerateFunction extends Command {
   async run() {
     const {flags} = this.parse(GenerateFunction)
 
-    const functionNameRegex = /^[a-z][a-z0-9]{0,46}$/
+    if (flags.name.length > 47) {
+      this.error('Function names cannot contain more than 47 characters.')
+    }
+
+    const functionNameRegex = /^[a-z][a-z0-9]*$/
 
     if (!functionNameRegex.test(flags.name)) {
       this.error(
         'Function names must:\n' +
         '1. Start with a letter\n' +
-        '2. Contain only lowercase letters and numbers\n' +
-        '3. Be 47 or characters or less',
+        '2. Contain only lowercase letters and numbers',
       )
     }
 

--- a/test/commands/generate/function.test.ts
+++ b/test/commands/generate/function.test.ts
@@ -113,7 +113,7 @@ describe('sf generate:function', () => {
   test
   .command(['generate:function', `--name=${'x'.repeat(48)}`, '--language=javascript'])
   .catch(error => {
-    expect(error.message).to.include('Function names must')
+    expect(error.message).to.include('Function names cannot contain more than 47 characters.')
   })
   .it('does not allow a function name that contains more than 47 characters')
 })


### PR DESCRIPTION
Closes https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000L2AZYA0/view

Updates `generate:function` to enforce function naming conventions.