### PR TITLE
Update namespacing for query return objects in Node.js templates

### DIFF
--- a/templates/javascript/test/index.test.js.tpl
+++ b/templates/javascript/test/index.test.js.tpl
@@ -33,19 +33,16 @@ describe('Unit Tests', () => {
             'done': true,
             'records': [
                 {
-                    'attributes':
-                        {'type':'Account','url':'/services/data/v48.0/sobjects/Account/001xx000003GYNjAAO'},
-                        'Name':'Global Media'
+                    'type': 'Account',
+                    'fields': { 'Name': 'Global Media' }
                 },
                 {
-                    'attributes':
-                        {'type':'Account','url':'/services/data/v48.0/sobjects/Account/001xx000003GYNkAAO'},
-                        'Name':'Acme'
+                    'type': 'Account',
+                    'fields': { 'Name': 'Acme' }
                 },
                 {
-                    'attributes':
-                    {'type':'Account','url':'/services/data/v48.0/sobjects/Account/001xx000003GYNlAAO'},
-                    'Name':'salesforce.com'
+                    'type': 'Account',
+                    'fields': { 'Name': 'salesforce.com' }
                 }
             ]
         };

--- a/templates/typescript/test/index.test.ts.tpl
+++ b/templates/typescript/test/index.test.ts.tpl
@@ -34,19 +34,16 @@ describe('Unit Tests', () => {
             'done': true,
             'records': [
                 {
-                    'attributes':
-                        {'type':'Account','url':'/services/data/v48.0/sobjects/Account/001xx000003GYNjAAO'},
-                        'Name':'Global Media'
+                    'type': 'Account',
+                    'fields': { 'Name': 'Global Media' }
                 },
                 {
-                    'attributes':
-                        {'type':'Account','url':'/services/data/v48.0/sobjects/Account/001xx000003GYNkAAO'},
-                        'Name':'Acme'
+                    'type': 'Account',
+                    'fields': { 'Name': 'Acme' }
                 },
                 {
-                    'attributes':
-                    {'type':'Account','url':'/services/data/v48.0/sobjects/Account/001xx000003GYNlAAO'},
-                    'Name':'salesforce.com'
+                    'type': 'Account',
+                    'fields': { 'Name': 'salesforce.com' }
                 }
             ]
         };


### PR DESCRIPTION
Updates the return object format to match the new return namespacing from https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/31.

## TODO
- [x] test with local invocation
- [x] test using local `sfdx run:functions:start`