### PR TITLE
exit non-zero when a function reference deploy fails

### DIFF
--- a/src/commands/project/deploy/functions.ts
+++ b/src/commands/project/deploy/functions.ts
@@ -194,20 +194,22 @@ export default class ProjectDeployFunctions extends Command {
 
     const connection = org.getConnection()
 
+    let shouldExitNonZero = false
+
     const results = await Promise.all(references.map(async reference => {
       const result = await connection.metadata.upsert('FunctionReference', reference) as UpsertResult
       if (!result.success) {
-        this.log(`Unable to deploy FunctionReference for ${reference.fullName}.`)
+        shouldExitNonZero = true
+        cli.error(`Unable to deploy FunctionReference for ${reference.fullName}.`, {exit: false})
+        return result
+      }
+
+      if (!flags.quiet) {
+        this.log(`Reference for ${result.fullName} ${result.created ? herokuColor.cyan('created') : herokuColor.green('updated')}`)
       }
 
       return result
     }))
-
-    if (!flags.quiet) {
-      results.forEach(result => {
-        this.log(`Reference for ${result.fullName} ${result.created ? herokuColor.cyan('created') : herokuColor.green('updated')}`)
-      })
-    }
 
     // Remove any function references for functions that no longer exist
     const successfulReferences = results.reduce(
@@ -245,5 +247,9 @@ export default class ProjectDeployFunctions extends Command {
     }
 
     cli.action.stop()
+
+    if (shouldExitNonZero) {
+      cli.exit(1)
+    }
   }
 }


### PR DESCRIPTION
Closes https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000Mia3YAC/view

When deploying multiple functions, it's possible that they will all deploy to Heroku, but some function references might fail to update. Previously if this happened, we simply reported that there was a problem but then continued on like nothing was wrong. This was obviously not a good idea. This PR makes it so that we instead report the failed FunctionReference deploy and exit non-zero so that any automation tools can actually react to the error.