### PR TITLE
fix filepath

### DIFF
--- a/src/commands/run/function.ts
+++ b/src/commands/run/function.ts
@@ -6,7 +6,7 @@ import {cli} from 'cli-ux'
 import {HTTP, CloudEvent} from 'cloudevents'
 import {default as CE_CONSTANTS} from 'cloudevents/dist/constants'
 import * as fs from 'fs'
-import getStdin from '../../../src/lib/get-stdin'
+import getStdin from '../../lib/get-stdin'
 import {v4 as uuid} from 'uuid'
 
 import {updateBenny} from '../../install-benny'


### PR DESCRIPTION
Fixes the issue reported in https://heroku.slack.com/archives/CQ20PPUR4/p1621974397080800

The filepath here seemed to be causing issues when running the compiled output, so this PR simply points at the file more directly, which should translate successfully when compiled.