### PR TITLE
include public key in npm tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "/bin",
     "/lib",
     "/templates",
-    "/oclif.manifest.json"
+    "/oclif.manifest.json",
+    "/priv/public.key"
   ],
   "homepage": "https://github.com/heroku/sf-plugin-functions",
   "keywords": [


### PR DESCRIPTION
Fixes https://heroku.slack.com/archives/CQ20PPUR4/p1621976766085200?thread_ts=1621976217.084800&cid=CQ20PPUR4

This is a file that was included in the builds plugin but didn't get included when we moved it over into this plugin. (see https://github.com/heroku/sf-plugin-builds/blob/master/package.json#L65)