### PR TITLE
fix(cli): upsert all function references at once to avoid race condition

### DIFF
--- a/src/commands/project/deploy/functions.ts
+++ b/src/commands/project/deploy/functions.ts
@@ -197,18 +197,15 @@ export default class ProjectDeployFunctions extends Command {
 
     const results = await connection.metadata.upsert('FunctionReference', references) as UpsertResult[]
     results.forEach(result => {
-      console.log(result)
       if (!result.success) {
         shouldExitNonZero = true
-        cli.error(`Unable to deploy FunctionReference ${result.fullName}.`, {exit: false})
+        cli.error(`Unable to deploy FunctionReference for ${result.fullName}.`, {exit: false})
       }
 
       if (!flags.quiet) {
         this.log(`Reference for ${result.fullName} ${result.created ? herokuColor.cyan('created') : herokuColor.green('updated')}`)
       }
     })
-
-    console.log(results)
 
     // Remove any function references for functions that no longer exist
     const successfulReferences = results.reduce(

--- a/test/commands/project/deploy/functions.test.ts
+++ b/test/commands/project/deploy/functions.test.ts
@@ -34,18 +34,20 @@ const FUNCTION_REFS_MOCK = [
 const USERNAME = 'fakeusername@salesforce.com'
 
 const METADATA_MOCK = {
-  upsert: (type: string, ref: any) => {
-    if (ref.fullName.includes('error')) {
+  upsert: (type: string, refs: any[]) => {
+    return refs.map(ref => {
+      if (ref.fullName.includes('error')) {
+        return {
+          fullName: ref.fullName,
+          success: false,
+        }
+      }
       return {
         fullName: ref.fullName,
-        success: false,
+        success: true,
+        created: true,
       }
-    }
-    return {
-      fullName: ref.fullName,
-      success: true,
-      created: true,
-    }
+    })
   },
   list: () => {
     return FUNCTION_REFS_MOCK.map(ref => {


### PR DESCRIPTION
Upserting all of the function references at once allows us to avoid a race condition that causes an error that we were facing when upserting each one with its own command. 