### PR TITLE
ci: fix CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,12 @@
 ---
 version: 2.1
 jobs:
-  node-16: &test
+  node:
+    parameters:
+      node-version:
+        type: string
     docker:
-      - image: node:16
+      - image: node:<< parameters.node-version >>
     working_directory: ~/cli
     steps:
       - checkout
@@ -18,16 +21,9 @@ jobs:
       - run:
           name: Testing
           command: yarn test
-  node-12:
-    <<: *test
-    docker:
-      - image: node:12
-  node-14:
-    <<: *test
-    docker:
-      - image: node:14
   cache:
-    <<: *test
+    docker:
+      - image: node:16
     steps:
       - checkout
       - run:
@@ -67,21 +63,26 @@ workflows:
   version: 2
   "sf-plugin-functions":
     jobs:
-      - node-16
-      - node-14
-      - node-12
-      - cache:
-          filters:
+      - node:
+          matrix:
+            parameters:
+              node-version:
+                - "12"
+                - "14"
+                - "16"
+          filters: &always_run
             tags:
-              only: /^v.*/
+              only: /.*/
             branches:
-              ignore: /.*/
+              only: /.*/
+          requires:
+            - cache
+      - cache:
+          filters: *always_run
       - release:
           context: functions-cli
           requires:
-            - node-16
-            - node-14
-            - node-12
+            - node
           filters:
             tags:
               only: /^v.*/


### PR DESCRIPTION
[GUS](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000NWtwYAG/view)

the `release` job depended on the `node-*` jobs, but the `node-*` jobs
did not declare a `tags` filter, so they were not run on tags.

Per the [CircleCI documentation][1]:

> Additionally, if a job requires any other jobs (directly or
indirectly), you must specify tag filters for those jobs.

This commit updates the `node-*` jobs to declare a `tags` filter so they
always run on every job. It also updates the CircleCI config to update
the `node` jobs to use CircleCI's matrix feature, so we don't have to
keep track of configurations between node versions. This will make
updating CircleCI easier when we need to update Node.js based on the
Node.js LTS release schedule

[1]: https://circleci.com/docs/2.0/configuration-reference/#tags