### PR TITLE
ci: publish unsigned version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,10 @@ jobs:
             echo unsafe-perm = true >> ~/.npmrc
             echo ${SALESFORCE_KEY} | base64 --decode > ~/salesforce-cli.key
       - run:
-          name: Sign and publish
-          command: ./bin/publish
+          # name: Sign and publish
+          # command: ./bin/publish
+          name: Publish unsigned
+          command: npm publish
 
 workflows:
   version: 2


### PR DESCRIPTION
This signing job has never worked and this package is currently in beta and has been released unsigned thus far.

[GUS](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000NWtwYAG/view)

**TODO**
+ [x] wait until the `SF_PUBLISH_NPM_TOKEN` value is updated in the `functions-cli` circle context