### PR TITLE
fix(cli): show compute env alias on env:list

### DIFF
--- a/src/commands/env/list.ts
+++ b/src/commands/env/list.ts
@@ -114,7 +114,7 @@ export default class EnvList extends Command {
     return Promise.all(envs.map(async env => {
       return {
         ...env,
-        alias: await this.resolveAliasForValue(env.name!),
+        alias: await this.resolveAliasForValue(env.id!),
       }
     }))
   }


### PR DESCRIPTION
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000LhzfYAC/view

to test:

- Run env:list command and see that there is no alias for compute environments
- Pull down branch and try again, and see that there is an alias for compute environments