### PR TITLE
fix: guard against undefined in metadata list in `env:delete` command

### DIFF
--- a/src/lib/function-reference-utils.ts
+++ b/src/lib/function-reference-utils.ts
@@ -28,7 +28,13 @@ export function splitFullName(fullName: string): FullNameReference {
   };
 }
 
-export function ensureArray<T>(refList: T | T[]): T[] {
+export function ensureArray<T>(refList?: T | T[]): T[] {
+  if (!refList) {
+    // Since the metadata API can sometimes return `undefined` rather than an empty array if no
+    // records are found, we cast it into an empty array to avoid any weird "cannot read property
+    // foo of undefined" errors further down
+    return [];
+  }
   if (!Array.isArray(refList)) {
     refList = [refList];
   }

--- a/test/commands/env/delete.test.ts
+++ b/test/commands/env/delete.test.ts
@@ -79,8 +79,7 @@ describe('env:delete', () => {
 
   test
     .stderr()
-    .nock('https://api.heroku.com', (api) => api.get(`/apps/${COMPUTE_ENV_NAME}`).reply(200))
-    .nock('https://api.heroku.com', (api) => api.delete(`/apps/${COMPUTE_ENV_NAME}`).reply(404))
+    .nock('https://api.heroku.com', (api) => api.get(`/apps/${COMPUTE_ENV_NAME}`).reply(404))
     .do(() => {
       sandbox.stub(EnvDelete.prototype, 'resolveScratchOrg' as any).returns({});
       sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);


### PR DESCRIPTION
### What does this PR do?

The `list` command for the Metadata API apparently returns `undefined` instead of an empty list when no results are found. This breaks some of the subsequent code that assumes an array, so this PR ensures that it will be an array.

In addition, this PR condenses the `try`/`catch` logic so that only the request to verify that the app exists is wrapped in a try/catch where the catch will print an error about the environment not existing. Previously, the majority of the `run` method was wrapped in this try/catch and that caused it to swallow up all sorts of errors that had nothing to do with the app not existing.

### What issues does this PR fix or reference?
@W-9497101@