### PR TITLE
fix: upsert function references sequentially

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ node_modules
 
 # ignore downloaded benny binary
 /bin/benny-*
+
+# don't ignore the actual lib folder in our source code
+!src/lib

--- a/src/lib/batch-call.ts
+++ b/src/lib/batch-call.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { chunk } from 'lodash';
+import { ensureArray } from './function-reference-utils';
+
+export async function batchCall<T, U>(data: T[], fn: (chunk: T[]) => Promise<U[] | U>) {
+  const chunked = chunk(data, 10);
+  let results: U[] = [];
+
+  for (const chunk of chunked) {
+    const result = await fn(chunk);
+
+    results = [...results, ...ensureArray(result)];
+  }
+
+  return results;
+}
+
+export default batchCall;


### PR DESCRIPTION
### What does this PR do?

In [a previous PR](https://github.com/salesforcecli/plugin-functions/pull/63) we tweaked the `FunctionReference` deploy step so that it uploaded all references at once rather than one at a time in parallel in order to avoid a race condition where most references ended up not getting deployed since the org expects deployments to occur sequentially.

This worked great, until someone tried to deploy >10 references and we discovered that the batch `upsert` method had a limit of 10 records per upsert.

This PR addresses this problem by batching function references into groups of 10 and upserting them *in sequence*, waiting for the first batch of 10 references to finish deploying before attempting to upload the next batch.

### What issues does this PR fix or reference?
@W-9484760@

### Steps to test

1. Create a project, scratch org with functions enabled, and compute environment
2. Generate 12 functions
3. `sfdx project:deploy:functions -o <your org>`
4. Check that it doesn't fail
5. Check that all function references were actually deployed (the VS Code extension or a SOQL query will help with this)
6. Delete all but one of the functions from your local project
7. Run project deploy functions
8. Verify that 11 function references were deleted and one remains