### PR TITLE
fix: add --extended hidden flag for debugging

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -12,7 +12,7 @@
   {
     "command": "env:display",
     "plugin": "@salesforce/plugin-functions",
-    "flags": ["environment", "verbose"]
+    "flags": ["environment", "extended", "verbose"]
   },
   {
     "command": "env:list",

--- a/src/lib/base.ts
+++ b/src/lib/base.ts
@@ -130,9 +130,9 @@ export default abstract class Command extends Base {
     // Check if the environment provided is an alias or not, to determine what app name we use to attempt deletion
     const aliases = await Aliases.create({});
     const matchingAlias = aliases.get(appNameOrAlias);
-    let appName;
+    let appName: string;
     if (matchingAlias) {
-      appName = matchingAlias;
+      appName = matchingAlias as string;
     } else {
       appName = appNameOrAlias;
     }


### PR DESCRIPTION
### What does this PR do?
We've had folks request a hidden flag that would show a few extra pieces of information (app ID and space ID) that are useful in support/debugging situations for compute environments.

This PR also reorganizes the key/value table so that functions is always at the bottom since it's the only multi-line field.


### What issues does this PR fix or reference?
@W-9515549@