### PR TITLE
fix: batch reference deletion in env:delete

### DIFF
--- a/src/commands/env/delete.ts
+++ b/src/commands/env/delete.ts
@@ -18,6 +18,7 @@ import {
 } from '../../lib/function-reference-utils';
 import { FunctionsFlagBuilder, confirmationFlag } from '../../lib/flags';
 import Command from '../../lib/base';
+import batchCall from '../../lib/batch-call';
 
 export default class EnvDelete extends Command {
   static description = 'delete an environment';
@@ -115,7 +116,7 @@ export default class EnvDelete extends Command {
         return acc;
       }, []);
       const referencesToRemove = filterProjectReferencesToRemove(allReferences, [], project.name);
-      await connection.metadata.delete('FunctionReference', referencesToRemove);
+      await batchCall(referencesToRemove, (chunk) => connection.metadata.delete('FunctionReference', chunk));
     }
 
     // Delete the application


### PR DESCRIPTION
### What does this PR do?
Follow-on to https://github.com/salesforcecli/plugin-functions/pull/94 that applies the same logic to `env:delete` so that when we clean up references for an environment that has >10 functions, we're able to batch the reference deletions.

### What issues does this PR fix or reference?
@W-9484760@