### PR TITLE
Run function: Adding tests to run:function tracking error handling and spinner

### DIFF
--- a/test/commands/run/function.test.ts
+++ b/test/commands/run/function.test.ts
@@ -12,7 +12,6 @@ import { MockTestOrgData, testSetup } from '@salesforce/core/lib/testSetup';
 import * as sinon from 'sinon';
 
 import * as library from '@heroku/functions-core';
-import Sinon = require('sinon');
 
 describe('run:function', () => {
   const $$ = testSetup();
@@ -21,7 +20,7 @@ describe('run:function', () => {
   let testData: MockTestOrgData;
   let sandbox: sinon.SinonSandbox;
   let runFunctionStub: sinon.SinonStub;
-  let stopActionSub: Sinon.SinonStub;
+  let stopActionSub: sinon.SinonStub;
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     runFunctionStub = sandbox.stub(library, 'runFunction');


### PR DESCRIPTION
### What does this PR do?
This PR adds tests that ensure the `cli.action` spinner for running a function is stopped correctly when:
 - A function is invoked successfully
 - A function innovation failed with a response
 - Invoking a function fails without a response (unhandled errors)
 
Not a fix for anything, but I think it's an appropriate followup action to https://github.com/salesforcecli/plugin-functions/pull/97
### What issues does this PR fix or reference?
@W-9457728@

