### PR TITLE
fix: fix core dependency version due to core dep bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@heroku/project-descriptor": "0.0.5",
     "@oclif/core": "^0.5.17",
     "@oclif/plugin-not-found": "^1.2.4",
-    "@salesforce/core": "^3.1.1-v3.2",
+    "@salesforce/core": "3.1.1-v3.2",
     "@salesforce/plugin-org": "^1.6.7",
     "@salesforce/plugin-project-utils": "^0.0.6",
     "@salesforce/templates": "^52.0.0",


### PR DESCRIPTION
### What does this PR do?
Fixes the `@salesforce/core` version to `3.1.1-v3.2` so that we don't use `v3.3` where a bug was introduced

### What issues does this PR fix or reference?
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000RJ9CYAW/view
