### PR TITLE
chore: automate release promotion after canaries pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,17 +90,17 @@ workflows:
           pre-job-steps:
             - release-management/pin-dependencies:
                 tag: latest
+      - canaries:
+          requires:
+            - release-management/release-package
+          filters:
+            branches:
+              only: main
       - release-management/promote-package:
           target: latest
           candidate: prerelease
           requires:
-            - release-management/test-package
-          filters:
-            branches:
-              only: release
-      - canaries:
-          requires:
-            - release-management/release-package
+            - canaries
           filters:
             branches:
               only: main


### PR DESCRIPTION
The current release flow involving merging to main, waiting on canaries, then opening a PR to merge `main` into `release` and waiting on CI all over again has proven more cumbersome and error-prone than we'd originally hoped.

That said, now that we've got canaries running as part of the CI flow, we can also automate the final steps of this process and obviate the need for a `release` branch entirely, as well as the process for keeping it up to date.

This PR tweaks the CI config so that, *on a merge to `main`*, CI will:
1. Run the tests
2. Publish the package to `npm` tagged as `prerelease`
3. Run the prerelease canaries
4. Promote the package from `prerelease` to `latest` upon successful completion of the canaries.


[skip-validate-pr]