### PR TITLE
fix: don't filter logs by app token

### DIFF
--- a/src/commands/env/log/tail.ts
+++ b/src/commands/env/log/tail.ts
@@ -106,7 +106,6 @@ export default class LogTail extends Command {
 
     const response = await this.client.post<Heroku.LogSession>(`/apps/${appName}/log-sessions`, {
       data: {
-        source: 'app',
         tail: true,
       },
     });


### PR DESCRIPTION
### What does this PR do?

This PR removes the `source` parameter from the request for logs. Previously, we had a hard-coded filter for only the `app` tokens in the logs, but this elides a lot of important information that can be found under the `heroku` token. Going forward, tailing logs will show all the available logs.

### What issues does this PR fix or reference?
@W-9667462@

### Steps to test
Run `env:log:tail` on a compute environment and verify that it still works.