### PR TITLE
chore(cli): upgrade salesforce core to 3.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@heroku/project-descriptor": "0.0.5",
     "@oclif/core": "^0.5.17",
     "@oclif/plugin-not-found": "^1.2.4",
-    "@salesforce/core": "3.1.1-v3.2",
+    "@salesforce/core": "3.3.1",
     "@salesforce/plugin-org": "^1.6.7",
     "@salesforce/plugin-project-utils": "^0.0.6",
     "@salesforce/ts-sinon": "^1.3.18",

--- a/test/commands/run/function.test.ts
+++ b/test/commands/run/function.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { expect, test } from '@oclif/test';
-import { Config } from '@salesforce/core';
+import { Config, SfdxPropertyKeys } from '@salesforce/core';
 import { cli } from 'cli-ux';
 
 import { MockTestOrgData, testSetup } from '@salesforce/core/lib/testSetup';
@@ -50,7 +50,7 @@ describe('run:function', () => {
       $$.configStubs.GlobalInfo = { contents: { orgs: { [testData.username]: await testData.getConfig() } } };
 
       const config = await Config.create(Config.getDefaultOptions(true));
-      await config.set(Config.DEFAULT_USERNAME, testData.username);
+      await config.set(SfdxPropertyKeys.DEFAULT_USERNAME, testData.username);
       await config.write();
     });
 
@@ -73,7 +73,7 @@ describe('run:function', () => {
         'TestHeader',
         '--structured',
         '-o',
-        Config.DEFAULT_USERNAME,
+        SfdxPropertyKeys.DEFAULT_USERNAME,
       ])
       .it('Should call the library with all arguments', async () => {
         sinon.assert.calledWith(
@@ -83,7 +83,7 @@ describe('run:function', () => {
             .and(sinon.match.has('url', targetUrl))
             .and(sinon.match.has('headers', ['TestHeader']))
             .and(sinon.match.has('structured', true))
-            .and(sinon.match.has('targetusername', Config.DEFAULT_USERNAME))
+            .and(sinon.match.has('targetusername', SfdxPropertyKeys.DEFAULT_USERNAME))
         );
       });
     test

--- a/yarn.lock
+++ b/yarn.lock
@@ -876,18 +876,18 @@
     mkdirp "1.0.4"
     sfdx-faye "^1.0.9"
 
-"@salesforce/core@3.1.1-v3.2":
-  version "3.1.1-v3.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.1.1-v3.2.tgz#75665c66b51564312108238e6c1c20c8d815d339"
-  integrity sha512-eKWMPEgL85iP/z89rDWktJVdl6YOWO/YE5mxRumHoewog7x9ErAl3FMsTkfROyAQIsalig9VMtz169QLpPawOg==
+"@salesforce/core@3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.3.1.tgz#0e7ea5742fcbc167542d503bbd618d00142ce016"
+  integrity sha512-UCQ2VYJQthDazGGCaWgQpvpMcgGwaf0NC5d7SL2Qx/Lz9d/C/U7U0OeRBtBrjePodZp/HpEeTnrbGjut+3DaOw==
   dependencies:
     "@salesforce/bunyan" "^2.0.0"
     "@salesforce/kit" "^1.5.8"
     "@salesforce/schemas" "^1.0.1"
     "@salesforce/ts-types" "^1.5.13"
-    "@types/graceful-fs" "^4.1.3"
-    "@types/jsforce" "1.9.23"
-    "@types/mkdirp" "1.0.0"
+    "@types/graceful-fs" "^4.1.5"
+    "@types/jsforce" "^1.9.29"
+    "@types/mkdirp" "^1.0.1"
     debug "^3.1.0"
     graceful-fs "^4.2.4"
     jsen "0.6.6"
@@ -895,6 +895,7 @@
     jsonwebtoken "8.5.0"
     mkdirp "1.0.4"
     sfdx-faye "^1.0.9"
+    ts-retry-promise "^0.6.0"
 
 "@salesforce/core@^2.17.0", "@salesforce/core@^2.2.0", "@salesforce/core@^2.23.4":
   version "2.24.2"


### PR DESCRIPTION
### What does this PR do?

Upgrade to 3.3.1 which will allow us to use `OrgConfigProperties` for our hooks implementation.

### What issues does this PR fix or reference?

https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000TYNqYAO/view