### PR TITLE
fix: allow equals sign in config pair value

### DIFF
--- a/src/commands/env/var/set.ts
+++ b/src/commands/env/var/set.ts
@@ -32,7 +32,11 @@ export default class ConfigSet extends Command {
       if (elem.indexOf('=') === -1) {
         this.error(`${herokuColor.cyan(elem)} is invalid. Please use the format ${herokuColor.cyan('key=value')}`);
       }
-      const [key, value] = elem.split('=');
+
+      const equalsIndex = elem.indexOf('=');
+      const key = elem.slice(0, equalsIndex);
+      const value = elem.slice(equalsIndex + 1);
+
       return { ...acc, [key]: value };
     }, {});
   }

--- a/test/commands/env/var/set.test.ts
+++ b/test/commands/env/var/set.test.ts
@@ -42,6 +42,24 @@ describe('sf env:var:set', () => {
     });
 
   test
+    .stdout()
+    .stderr()
+    // Adding retries here because there is some kind of race condition that causes fancy-test to not
+    // fully capture the value of stderr when running in CI (╯°□°)╯︵ ┻━┻
+    .retries(2)
+    .nock('https://api.heroku.com', (api) =>
+      api
+        .patch('/apps/my-environment/config-vars', {
+          foo: 'bar=baz',
+        })
+        .reply(200)
+    )
+    .command(['env:var:set', 'foo=bar=baz', '--environment', 'my-environment'])
+    .it('allows equals sign in config pair value', (ctx) => {
+      expect(ctx.stderr).to.contain('Setting foo and restarting my-environment');
+    });
+
+  test
     .command(['env:var:set', 'foobar', '--environment', 'my-environment'])
     .catch((error) => {
       expect(error.message).to.contain('foobar is invalid. Please use the format key=value');


### PR DESCRIPTION
### What does this PR do?
Allows setting config vars with `=` in them.

Before, if you tried to set a config var like `foo='bar=baz'` in `env:var:set`, it would break because it splits on *every* `=` sign. Now it works with `foo='bar=baz'`

### What issues does this PR fix or reference?
[GUS Card](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000Qkp1YAC/view)
