### PR TITLE
fix: lock boolean dep while fix by boolean team is underway

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1869,7 +1869,7 @@ bn@^1.0.4, bn@^1.0.5:
   resolved "https://registry.yarnpkg.com/bn/-/bn-1.0.5.tgz#fdf5fdeede044884ea7ee62adff763ee99144fa5"
   integrity sha512-7TvGbqbZb6lDzsBtNz1VkdXXV0BVmZKPPViPmo2IpvwaryF7P+QKYKACyVkwo2mZPr2CpFiz7EtgPEcc3o/JFQ==
 
-boolean@^3.0.1:
+boolean@3.0.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/boolean/-/boolean-3.1.2.tgz#e30f210a26b02458482a8cc353ab06f262a780c2"
   integrity sha512-YN6UmV0FfLlBVvRvNPx3pz5W/mUoYB24J4WSXOKP/OOJpi+Oq6WYqPaNTHzjI0QzwWtnvEd5CGYyQPgp1jFxnw==


### PR DESCRIPTION
### What does this PR do?
Locks `boolean` dependency to `3.0.1` to prevent the current boolean update `3.1.3` from breaking node engines that are not running on 16.x.x.