### PR TITLE
feat: js and ts function templates now use js modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@heroku-cli/schema": "^1.0.25",
     "@heroku/eventsource": "^1.0.7",
     "@heroku/function-toml": "^0.0.3",
-    "@heroku/functions-core": "0.1.0",
+    "@heroku/functions-core": "0.1.1",
     "@heroku/project-descriptor": "0.0.5",
     "@oclif/core": "^0.5.17",
     "@oclif/plugin-not-found": "^1.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -400,10 +400,10 @@
     ajv "^6.12.2"
     toml "^3.0.0"
 
-"@heroku/functions-core@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@heroku/functions-core/-/functions-core-0.1.0.tgz#e43645fc3b49a3a17029747793991c68b8e8fa23"
-  integrity sha512-CdM/gApg8ny0adriBxikFqgAikAVQ2qAbrek2XWnag/OC3rxMo1FNttmtqwch70EGxalTsNAwAeAp3B3PDlsBA==
+"@heroku/functions-core@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@heroku/functions-core/-/functions-core-0.1.1.tgz#a1b1122305f1823265e5db0a4ce5b421a7d44ce4"
+  integrity sha512-PP+WtTTQzaJNYOvYwyXq/I96GKJVChPBfmiAmmheiyNiF/7uw4XoQvJeFQQH0M2zZVsAkHEWs41lvxVBpjjY2w==
   dependencies:
     "@heroku-cli/color" "^1.1.14"
     "@heroku/project-descriptor" "0.0.5"


### PR DESCRIPTION
### What does this PR do?

Updates functions-core to `0.1.1`. This has the effect of changing the JS and TS templates from CommonJS to JavaScript Modules / ESM. More on that is in the following related PRs:

- https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/99
- https://github.com/heroku/sf-functions-core/pull/10
- https://github.com/heroku/buildpacks-nodejs/pull/114

### What issues does this PR fix or reference?

[@W-9710399@](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07AH000000TEQrYAO)
