### PR TITLE
feat: add instanceurl flag to jwt login

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -77,7 +77,7 @@
   {
     "command": "login:functions:jwt",
     "plugin": "@salesforce/plugin-functions",
-    "flags": ["clientid", "keyfile", "username"]
+    "flags": ["clientid", "instanceurl", "keyfile", "username"]
   },
   {
     "command": "project:deploy:functions",

--- a/test/commands/login/functions/jwt.test.ts
+++ b/test/commands/login/functions/jwt.test.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { test } from '@oclif/test';
+import { expect, test } from '@oclif/test';
 import { AuthInfo, GlobalInfo, SfdxProject, SfTokens } from '@salesforce/core';
 import * as sinon from 'sinon';
 import { AuthStubs } from '../../../helpers/auth';
@@ -13,6 +13,7 @@ const PUBLIC_CLIENT_ID = '1e9cdca9-cec7-4dbf-ae84-408694b22bac';
 
 export const PROJECT_CONFIG_MOCK = {
   name: 'sweet_project',
+  sfdcLoginUrl: 'project-config-login.com',
 };
 const PROJECT_MOCK = {
   resolveProjectConfig() {
@@ -77,6 +78,99 @@ describe('sf login functions jwt', () => {
           token: 'herokutoken',
           url: 'https://cli-auth.heroku.com/',
           user: 'username',
+        },
+      });
+    });
+
+  test
+    .stdout()
+    .stderr()
+    .add('AuthInfoCreateStub', () => {
+      return sinon.stub(AuthInfo, 'create' as any).returns({
+        getFields() {
+          return {
+            accessToken: SFDX_ACCESS_TOKEN,
+          };
+        },
+        save: sinon.stub(),
+      });
+    })
+    .finally(() => sinon.restore())
+    .nock('https://api.heroku.com', (api) => {
+      api
+        .post('/oauth/tokens', {
+          client: {
+            id: PUBLIC_CLIENT_ID,
+          },
+          grant: {
+            type: 'urn:ietf:params:oauth:grant-type:token-exchange',
+          },
+          subject_token: SFDX_ACCESS_TOKEN,
+          subject_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+        })
+        .reply(201, {
+          access_token: {
+            token: HEROKU_ACCESS_TOKEN,
+          },
+        });
+      api.get('/account').reply(200, { salesforce_username: 'username' });
+    })
+    .command([
+      'login:functions:jwt',
+      '--username=foo@bar.com',
+      '--keyfile=keyfile.key',
+      '--clientid=12345',
+      '--instanceurl=foo.com',
+    ])
+    .it('will use an instance URL if passed', (ctx) => {
+      expect(ctx.AuthInfoCreateStub).to.have.been.calledWithMatch({
+        oauth2Options: {
+          loginUrl: 'foo.com',
+        },
+      });
+    });
+
+  test
+    .stdout()
+    .stderr()
+    .do(() => {
+      sinon.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
+    })
+    .add('AuthInfoCreateStub', () => {
+      return sinon.stub(AuthInfo, 'create' as any).returns({
+        getFields() {
+          return {
+            accessToken: SFDX_ACCESS_TOKEN,
+          };
+        },
+        save: sinon.stub(),
+      });
+    })
+    .finally(() => sinon.restore())
+    .nock('https://api.heroku.com', (api) => {
+      api
+        .post('/oauth/tokens', {
+          client: {
+            id: PUBLIC_CLIENT_ID,
+          },
+          grant: {
+            type: 'urn:ietf:params:oauth:grant-type:token-exchange',
+          },
+          subject_token: SFDX_ACCESS_TOKEN,
+          subject_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+        })
+        .reply(201, {
+          access_token: {
+            token: HEROKU_ACCESS_TOKEN,
+          },
+        });
+      api.get('/account').reply(200, { salesforce_username: 'username' });
+    })
+    .command(['login:functions:jwt', '--username=foo@bar.com', '--keyfile=keyfile.key', '--clientid=12345'])
+    .it('will use project config login URL if instanceurl is not passed', (ctx) => {
+      expect(ctx.AuthInfoCreateStub).to.have.been.calledWithMatch({
+        oauth2Options: {
+          loginUrl: PROJECT_CONFIG_MOCK.sfdcLoginUrl,
         },
       });
     });


### PR DESCRIPTION
### What does this PR do?

This PR adds a `--instanceurl` flag to `login:functions:jwt` that allows users to specify their own login URL, as well as allows the command to be run outside of a project directory.


### What issues does this PR fix or reference?
@W-9824655@