### PR TITLE
feat: use sf-plugins-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@oclif/plugin-not-found": "^1.2.4",
     "@salesforce/core": "3.3.1",
     "@salesforce/plugin-org": "^1.6.7",
-    "@salesforce/plugin-project-utils": "^0.0.6",
     "@salesforce/sf-plugins-core": "^0.0.15",
     "@salesforce/ts-sinon": "^1.3.18",
     "@salesforce/ts-types": "^1.5.5",
@@ -101,7 +100,9 @@
     "bin": "sf",
     "topicSeparator": " ",
     "hooks": {
-      "sf:deploy": "./lib/hooks/deploy"
+      "sf:deploy": "./lib/hooks/deploy",
+      "sf:env:list": "./lib/hooks/envList",
+      "sf:env:display": "./lib/hooks/envDisplay"
     },
     "plugins": [
       "@oclif/plugin-not-found"

--- a/src/hooks/envDisplay.ts
+++ b/src/hooks/envDisplay.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { SfHook } from '@salesforce/sf-plugins-core';
+
+type ComputeEnv = { name: string; active: boolean };
+
+const hook: SfHook.EnvDisplay<ComputeEnv> = async function () {
+  return { data: { name: 'hello', active: true } };
+};
+
+export default hook;

--- a/src/hooks/envList.ts
+++ b/src/hooks/envList.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { SfHook } from '@salesforce/sf-plugins-core';
+
+type ComputeEnv = { name: string; active: boolean };
+
+const hook: SfHook.EnvList<ComputeEnv> = async function () {
+  // return [
+  //   {
+  //     title: 'Compute Environments',
+  //     data: [
+  //       { name: 'hello', active: true },
+  //       { name: 'world', active: false },
+  //     ],
+  //   },
+  // ];
+  return [];
+};
+
+export default hook;

--- a/yarn.lock
+++ b/yarn.lock
@@ -987,16 +987,6 @@
     open "8.2.0"
     tslib "^2"
 
-"@salesforce/plugin-project-utils@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@salesforce/plugin-project-utils/-/plugin-project-utils-0.0.6.tgz#94a2798aac37d1392316a11c136b6af269cbf97d"
-  integrity sha512-NtxFc75mEFQU2J0LthD2fCzmZ32iy7TM37qgpbbEPcwJLsHaxeb7djzt7NkLQ1maAKzrgRFw0iLq4kzojqOybg==
-  dependencies:
-    "@salesforce/kit" "^1.5.8"
-    "@salesforce/ts-types" "^1.5.13"
-    cli-ux "^5.6.2"
-    inquirer "^8.1.1"
-
 "@salesforce/prettier-config@^0.0.2":
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/@salesforce/prettier-config/-/prettier-config-0.0.2.tgz#ded39bf7cb75238edc9db6dd093649111350f8bc"


### PR DESCRIPTION
### What does this PR do?

Uses new hook interface from [sf-plugins-core](https://github.com/salesforcecli/sf-plugins-core)

TODO:
- [ ] Move `env list` and `env display` logic out of commands and into hooks
- [ ] Remove `env list` and `env display`

### What issues does this PR fix or reference?
@W-9811480@