### PR TITLE
fix: remove project deploy alias

### DIFF
--- a/src/commands/deploy/functions.ts
+++ b/src/commands/deploy/functions.ts
@@ -51,8 +51,6 @@ export default class DeployFunctions extends Command {
     }),
   };
 
-  static aliases = ['project:deploy:functions'];
-
   async getCurrentBranch() {
     const statusString = await this.git?.status();
 


### PR DESCRIPTION
### What does this PR do?

Removes the `project deploy functions` alias from `deploy functions`

### What issues does this PR fix or reference?
[skip-validate-pr]