### PR TITLE
fix: ensure tokens are always written before lookup

### DIFF
--- a/src/commands/login/functions.ts
+++ b/src/commands/login/functions.ts
@@ -50,6 +50,8 @@ export default class Login extends Command {
 
     this.info.setToken(Command.TOKEN_BEARER_KEY, { token: bearerToken, url: this.identityUrl.toString() });
 
+    await this.info.write();
+
     const account = await this.fetchAccount();
 
     this.info.updateToken(Command.TOKEN_BEARER_KEY, { user: account.salesforce_username });


### PR DESCRIPTION
### What does this PR do?

We started encountering issues running `login:functions:jwt` in both CI and Heroku bash settings. The command would fail with an error message indicating that the user needed to log in...which is exactly what they were trying to do.

It turns out that the command actually just did not work in cases where there wasn't already a token (even an expired one) written into the `GlobalInfo` store, but we'd never encountered it before because every single person testing the `jwt` function has already logged in at least once. As a result, we missed what, in retrospect, was a very obvious bug: we were saving the token in the *in-memory* `GlobalInfo` store and then trying to reference it elsewhere before actually writing it out to a file.

This PR remedies that issue by always calling `this.info.write` immediately after setting the token. In addition, this PR fixes another issue the call to the token exchange was using the built-in API client rather than a vanilla HTTP client, which was also causing it to attempt to look up the token (which doesn't exist in CI).

### What issues does this PR fix or reference?

@W-9834542@
