### PR TITLE
fix: bump version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-functions",
   "description": "Functions plugin for the SF CLI",
-  "version": "0.2.32",
+  "version": "0.2.33",
   "author": "heroku-front-end@salesforce.com",
   "bin": {
     "functions": "./bin/run"


### PR DESCRIPTION
### What does this PR do?

Manual version bump bc versions got out of sync

### What issues does this PR fix or reference?
[skip-validate-pr]