### PR TITLE
fix: don't refetch username when logging in via JWT

### DIFF
--- a/src/commands/login/functions/jwt.ts
+++ b/src/commands/login/functions/jwt.ts
@@ -148,15 +148,11 @@ export default class JwtLogin extends Command {
     // the new heroku credentials we're about to generate
     this.resetClientAuth();
 
-    this.info.setToken(Command.TOKEN_BEARER_KEY, { token: bearerToken, url: this.identityUrl.toString() });
-
-    // We write early and often here to ensure that the token will always be correctly retrieved by
-    // `info.getToken` when run elsewhere (e.g. in `fetchAccount`)
-    await this.info.write();
-
-    const account = await this.fetchAccount();
-
-    this.info.updateToken(Command.TOKEN_BEARER_KEY, { user: account.salesforce_username });
+    this.info.setToken(Command.TOKEN_BEARER_KEY, {
+      token: bearerToken,
+      url: this.identityUrl.toString(),
+      user: auth.getUsername(),
+    });
 
     await this.info.write();
 

--- a/test/commands/login/functions/jwt.test.ts
+++ b/test/commands/login/functions/jwt.test.ts
@@ -45,6 +45,7 @@ describe('sf login functions jwt', () => {
           };
         },
         save: sinon.stub(),
+        getUsername: sinon.stub().returns('username'),
       });
 
       sinon.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
@@ -69,7 +70,6 @@ describe('sf login functions jwt', () => {
             token: HEROKU_ACCESS_TOKEN,
           },
         });
-      api.get('/account').reply(200, { salesforce_username: 'username' });
     })
     .command(['login:functions:jwt', '--username=foo@bar.com', '--keyfile=keyfile.key', '--clientid=12345'])
     .it('can save a bearer token from heroku identity service', () => {
@@ -93,6 +93,7 @@ describe('sf login functions jwt', () => {
           };
         },
         save: sinon.stub(),
+        getUsername: sinon.stub().returns('username'),
       });
     })
     .finally(() => sinon.restore())
@@ -113,7 +114,6 @@ describe('sf login functions jwt', () => {
             token: HEROKU_ACCESS_TOKEN,
           },
         });
-      api.get('/account').reply(200, { salesforce_username: 'username' });
     })
     .command([
       'login:functions:jwt',
@@ -144,6 +144,7 @@ describe('sf login functions jwt', () => {
           };
         },
         save: sinon.stub(),
+        getUsername: sinon.stub().returns('username'),
       });
     })
     .finally(() => sinon.restore())
@@ -164,7 +165,6 @@ describe('sf login functions jwt', () => {
             token: HEROKU_ACCESS_TOKEN,
           },
         });
-      api.get('/account').reply(200, { salesforce_username: 'username' });
     })
     .command(['login:functions:jwt', '--username=foo@bar.com', '--keyfile=keyfile.key', '--clientid=12345'])
     .it('will use project config login URL if instanceurl is not passed', (ctx) => {


### PR DESCRIPTION
### What does this PR do?

As part of a bug investigation, I realized that `login:functions:jwt` was unnecessarily fetching the salesforce account username and setting it when we actually already have access to it in the command itself (since a username has to be passed in for the headless version of the login command).

This PR simply removes the extra work.

### What issues does this PR fix or reference?
@W-9890904@