### PR TITLE
Add alias flags and `--json` to `login:functions:jwt`

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -82,7 +82,7 @@
   {
     "command": "login:functions:jwt",
     "plugin": "@salesforce/plugin-functions",
-    "flags": ["alias", "clientid", "instanceurl", "json", "keyfile", "set-default", "set-default-dev-hub", "username"]
+    "flags": ["alias", "clientid", "instance-url", "json", "keyfile", "set-default", "set-default-dev-hub", "username"]
   },
   {
     "command": "run:function",

--- a/messages/login.functions.jwt.md
+++ b/messages/login.functions.jwt.md
@@ -18,7 +18,7 @@ Path to JWT keyfile.
 
 OAuth client ID.
 
-# flags.instanceurl.summary
+# flags.instance-url.summary
 
 The login URL of the instance the org lives on.
 

--- a/src/commands/login/functions/jwt.ts
+++ b/src/commands/login/functions/jwt.ts
@@ -56,9 +56,9 @@ export default class JwtLogin extends Command {
       char: 'i',
       description: messages.getMessage('flags.clientid.summary'),
     }),
-    instanceurl: Flags.string({
-      char: 'r',
-      description: messages.getMessage('flags.instanceurl.summary'),
+    'instance-url': Flags.string({
+      char: 'l',
+      description: messages.getMessage('flags.instance-url.summary'),
     }),
     json: Flags.boolean({
       description: messages.getMessage('flags.json.summary'),
@@ -125,13 +125,13 @@ export default class JwtLogin extends Command {
 
   async run() {
     const { flags } = await this.parse(JwtLogin);
-    const { clientid, username, keyfile, instanceurl } = flags;
+    const { clientid, username, keyfile, 'instance-url': instanceUrl } = flags;
 
     cli.action.start('Logging in via JWT');
 
     // Use keyfile, clientid, and username to auth with salesforce via the same workflow
     // as sfdx auth:jwt:grant --json
-    const auth = await this.initAuthInfo(username, clientid, keyfile, instanceurl);
+    const auth = await this.initAuthInfo(username, clientid, keyfile, instanceUrl);
 
     // Take care of any alias/default setting that needs to happen for the sfdx credential
     // before we move on to the heroku stuff

--- a/test/commands/login/functions/jwt.test.ts
+++ b/test/commands/login/functions/jwt.test.ts
@@ -115,7 +115,7 @@ describe('sf login functions jwt', () => {
       '--username=foo@bar.com',
       '--keyfile=keyfile.key',
       '--clientid=12345',
-      '--instanceurl=foo.com',
+      '--instance-url=foo.com',
     ])
     .it('will use an instance URL if passed', (ctx) => {
       expect(ctx.AuthInfoCreateStub).to.have.been.calledWithMatch({
@@ -154,7 +154,7 @@ describe('sf login functions jwt', () => {
         });
     })
     .command(['login:functions:jwt', '--username=foo@bar.com', '--keyfile=keyfile.key', '--clientid=12345'])
-    .it('will use project config login URL if instanceurl is not passed', (ctx) => {
+    .it('will use project config login URL if instanc-eurl is not passed', (ctx) => {
       expect(ctx.AuthInfoCreateStub).to.have.been.calledWithMatch({
         oauth2Options: {
           loginUrl: PROJECT_CONFIG_MOCK.sfdcLoginUrl,


### PR DESCRIPTION
### What does this PR do?

Add flags for setting an alias, setting default org, and setting default dev hub so that this command mirrors the functionality of `auth:jwt:grant` more closely. `login:functions:jwt` will authenticate the user with BOTH salesforce and functions, so we want to expose all the same flags to make it as close to a drop-in replacement.

Note that this command also uses the new `target-org` and `target-dev-hub` nomenclature, rather than the old `defaultusername` and `defaultdevhubusername`

### What issues does this PR fix or reference?
@W-9882832@