### PR TITLE
fix: support the old version of instance url flag

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -82,7 +82,17 @@
   {
     "command": "login:functions:jwt",
     "plugin": "@salesforce/plugin-functions",
-    "flags": ["alias", "clientid", "instance-url", "json", "keyfile", "set-default", "set-default-dev-hub", "username"]
+    "flags": [
+      "alias",
+      "clientid",
+      "instance-url",
+      "instanceurl",
+      "json",
+      "keyfile",
+      "set-default",
+      "set-default-dev-hub",
+      "username"
+    ]
   },
   {
     "command": "run:function",

--- a/messages/login.functions.jwt.md
+++ b/messages/login.functions.jwt.md
@@ -37,3 +37,7 @@ Set the org as the default that all org-related commands run against.
 # flags.set-default-dev-hub.summary
 
 Set the org as the default Dev Hub for scratch org creation.
+
+# flags.instanceurl.deprecation
+
+--instanceurl is deprecated and will be removed in a future release. Please use --instance-url going forward.

--- a/src/commands/login/functions/jwt.ts
+++ b/src/commands/login/functions/jwt.ts
@@ -59,6 +59,13 @@ export default class JwtLogin extends Command {
     'instance-url': Flags.string({
       char: 'l',
       description: messages.getMessage('flags.instance-url.summary'),
+      exclusive: ['instanceurl'],
+    }),
+    instanceurl: Flags.string({
+      char: 'l',
+      description: messages.getMessage('flags.instance-url.summary'),
+      exclusive: ['instance-url'],
+      hidden: true,
     }),
     json: Flags.boolean({
       description: messages.getMessage('flags.json.summary'),
@@ -125,7 +132,13 @@ export default class JwtLogin extends Command {
 
   async run() {
     const { flags } = await this.parse(JwtLogin);
-    const { clientid, username, keyfile, 'instance-url': instanceUrl } = flags;
+    const { clientid, username, keyfile } = flags;
+    // We support both versions of the flag here for the sake of backward compat
+    const instanceUrl = flags['instance-url'] ?? flags.instanceurl;
+
+    if (flags.instanceurl) {
+      this.warn(messages.getMessage('flags.instanceurl.deprecation'));
+    }
 
     cli.action.start('Logging in via JWT');
 


### PR DESCRIPTION
### What does this PR do?
This is a follow-on to https://github.com/salesforcecli/plugin-functions/pull/205.

It adds `--instanceurl` as a hidden, undocumented flag so that existing CI scripts, integration, demos, and whatever else will continue to work when using headless auth, while still pushing new users to the style-guide compliant `--instance-url`.

### What issues does this PR fix or reference?
@W-9882832@