### PR TITLE
cli(fix): Add error logic & messaging for env:var:unset

### DIFF
--- a/src/commands/env/var/unset.ts
+++ b/src/commands/env/var/unset.ts
@@ -39,16 +39,6 @@ export default class ConfigUnset extends Command {
       throw new Errors.CLIError('you must enter a config var key (i.e. mykey)');
     }
 
-    const { data: config } = await this.client.get<Heroku.ConfigVars>(`/apps/${appName}/config-vars`);
-
-    const value = config[argv[0]];
-
-    if (!value) {
-      throw new Errors.CLIError(
-        `No config var named ${herokuColor.cyan(argv[0])} found for environment ${herokuColor.cyan(environment)}`
-      );
-    }
-
     const configPairs = argv.reduce((acc, elem) => {
       return {
         ...acc,

--- a/test/commands/env/var/unset.test.ts
+++ b/test/commands/env/var/unset.test.ts
@@ -12,8 +12,6 @@ describe('sf env:var:unset', () => {
     .stderr()
     .nock('https://api.heroku.com', (api) =>
       api
-        .get('/apps/my-environment/config-vars')
-        .reply(200, { foo: 'bar' })
         .patch('/apps/my-environment/config-vars', {
           foo: null,
         })
@@ -29,8 +27,6 @@ describe('sf env:var:unset', () => {
     .stderr()
     .nock('https://api.heroku.com', (api) =>
       api
-        .get('/apps/my-environment/config-vars')
-        .reply(200, { foo: 'bar', bar: 'zoo' })
         .patch('/apps/my-environment/config-vars', {
           foo: null,
           bar: null,


### PR DESCRIPTION
### What does this PR do?
Make command error if no arguments are given or if the user tries to unset a config var that doesn't exist

### What issues does this PR fix or reference?
@W-9923568@