### PR TITLE
feat: add logout:functions command

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -85,6 +85,11 @@
     ]
   },
   {
+    "command": "logout:functions",
+    "plugin": "@salesforce/plugin-functions",
+    "flags": []
+  },
+  {
     "command": "run:function",
     "plugin": "@salesforce/plugin-functions",
     "flags": ["connected-org", "headers", "payload", "structured", "url"]

--- a/messages/logout.functions.md
+++ b/messages/logout.functions.md
@@ -1,0 +1,11 @@
+# summary
+
+Log out of your Salesforce Functions account.
+
+# examples
+
+$ sfdx logout:functions
+
+# action.start
+
+Logging out of Salesforce Functions

--- a/src/commands/logout/functions.ts
+++ b/src/commands/logout/functions.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { cli } from 'cli-ux';
+import { Messages } from '@salesforce/core';
+
+import Command from '../../lib/base';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-functions', 'logout.functions');
+
+export default class Login extends Command {
+  static description = messages.getMessage('summary');
+
+  static examples = messages.getMessages('examples');
+
+  async run() {
+    cli.action.start(messages.getMessage('action.start'));
+
+    this.info.unsetToken(Command.TOKEN_BEARER_KEY);
+    await this.info.write();
+
+    cli.action.stop();
+  }
+}

--- a/test/commands/logout/functions.test.ts
+++ b/test/commands/logout/functions.test.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { test } from '@oclif/test';
+import type { GlobalInfo, SfTokens } from '@salesforce/core';
+import * as sinon from 'sinon';
+import { AuthStubs } from '../../helpers/auth';
+
+describe('sf logout functions', () => {
+  let contents: SfTokens;
+
+  beforeEach(() => {
+    AuthStubs.write.callsFake(async function (this: GlobalInfo) {
+      contents = this.getTokens(true);
+      return this.getContents();
+    });
+  });
+
+  test
+    .stdout()
+    .stderr()
+    .command(['logout:functions'])
+    .it('removes the functions key from the tokens field on logout', (ctx) => {
+      sinon.assert.match(contents, {});
+    });
+});


### PR DESCRIPTION
### What does this PR do?

This PR adds functions-specific logout functionality. All it does is delete their functions token from the global info store. It does not log them out from any salesforce orgs or anything else.

## To test
1. `sfdx login:functions`
2. `less ~/.sf/sf.json`
3. Verify that the `tokens` key has a `functions-bearer` key with your token in it
4. press `q` to exit
4. `sfdx logout:functions`
5. `less ~/.sf/sf.json`
6. Verify that the tokens key is now an empty object.

### What issues does this PR fix or reference?
@W-9892680@