### PR TITLE
chore: upgrade @salesforce/core

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@heroku/project-descriptor": "0.0.5",
     "@oclif/core": "0.5.39",
     "@oclif/plugin-not-found": "^1.2.4",
-    "@salesforce/core": "3.3.1",
+    "@salesforce/core": "3.6.4",
     "@salesforce/plugin-org": "^1.6.7",
     "@salesforce/sf-plugins-core": "^0.0.25",
     "@salesforce/ts-sinon": "^1.3.18",

--- a/src/commands/env/create/compute.ts
+++ b/src/commands/env/create/compute.ts
@@ -7,7 +7,7 @@
 import herokuColor from '@heroku-cli/color';
 import * as Heroku from '@heroku-cli/schema';
 import { Flags } from '@oclif/core';
-import { Aliases, Messages } from '@salesforce/core';
+import { Messages } from '@salesforce/core';
 import { QueryResult } from 'jsforce';
 import { cli } from 'cli-ux';
 import { format } from 'date-fns';
@@ -153,11 +153,9 @@ export default class EnvCreateCompute extends Command {
       cli.action.start('Connecting environments');
 
       if (alias) {
-        const aliases = await Aliases.create({});
+        this.info.aliases.set(alias, app.id!);
 
-        aliases.set(alias, app.id);
-
-        await aliases.write();
+        await this.info.write();
       }
 
       cli.action.stop();

--- a/src/commands/env/delete.ts
+++ b/src/commands/env/delete.ts
@@ -107,7 +107,7 @@ export default class EnvDelete extends Command {
       // connected to, in which case `resolveOrg` will error and we simply want to skip the process
       // of cleaning up functon refs since they're all already gone. Otherwise, something else has
       // gone wrong and we go ahead and bail out.
-      if (error.message !== 'Attempted to resolve an org without an org ID or defaultusername value') {
+      if (error.message !== 'Attempted to resolve an org without an org ID or target-org value') {
         this.error;
       }
     }

--- a/src/commands/login/functions.ts
+++ b/src/commands/login/functions.ts
@@ -48,16 +48,16 @@ export default class Login extends Command {
 
     const refreshToken = response.data.refresh_token;
 
-    this.info.setToken(Command.TOKEN_BEARER_KEY, { token: bearerToken, url: this.identityUrl.toString() });
+    this.info.tokens.set(Command.TOKEN_BEARER_KEY, { token: bearerToken, url: this.identityUrl.toString() });
 
     await this.info.write();
 
     const account = await this.fetchAccount();
 
-    this.info.updateToken(Command.TOKEN_BEARER_KEY, { user: account.salesforce_username });
+    this.info.tokens.update(Command.TOKEN_BEARER_KEY, { user: account.salesforce_username });
 
     if (refreshToken) {
-      this.info.setToken(Command.TOKEN_REFRESH_KEY, {
+      this.info.tokens.set(Command.TOKEN_REFRESH_KEY, {
         token: refreshToken,
         url: this.identityUrl.toString(),
         user: account.salesforce_username,

--- a/src/commands/login/functions/jwt.ts
+++ b/src/commands/login/functions/jwt.ts
@@ -196,7 +196,7 @@ export default class JwtLogin extends Command {
     // the new heroku credentials we're about to generate
     this.resetClientAuth();
 
-    this.info.setToken(Command.TOKEN_BEARER_KEY, {
+    this.info.tokens.set(Command.TOKEN_BEARER_KEY, {
       token: bearerToken,
       url: this.identityUrl.toString(),
       user: auth.getUsername(),

--- a/src/commands/logout/functions.ts
+++ b/src/commands/logout/functions.ts
@@ -20,7 +20,7 @@ export default class Login extends Command {
   async run() {
     cli.action.start(messages.getMessage('action.start'));
 
-    this.info.unsetToken(Command.TOKEN_BEARER_KEY);
+    this.info.tokens.unset(Command.TOKEN_BEARER_KEY);
     await this.info.write();
 
     cli.action.stop();

--- a/src/commands/run/function.ts
+++ b/src/commands/run/function.ts
@@ -70,16 +70,16 @@ export default class Invoke extends Command {
       this.error('no payload provided (provide via stdin or -p)');
     }
     const aggregator = await ConfigAggregator.create();
-    const defaultusername = aggregator.getPropertyValue('defaultusername');
-    if (!flags['connected-org'] && !defaultusername) {
-      this.warn('No -o connected org or defaultusername found, context will be partially initialized');
+    const targetOrg = aggregator.getPropertyValue('target-org');
+    if (!flags['connected-org'] && !targetOrg) {
+      this.warn('No -o connected org or target-org found, context will be partially initialized');
     }
-    const aliasOrUser = flags['connected-org'] || `defaultusername ${defaultusername}`;
+    const aliasOrUser = flags['connected-org'] || `target-org ${targetOrg}`;
     this.log(`Using ${aliasOrUser} login credential to initialize context`);
     const runFunctionOptions = {
       url,
       ...flags,
-      targetusername: flags['connected-org'] ?? defaultusername,
+      targetusername: flags['connected-org'] ?? targetOrg,
     };
     cli.action.start(`${herokuColor.cyanBright('POST')} ${url}`);
     try {

--- a/src/hooks/deploy.ts
+++ b/src/hooks/deploy.ts
@@ -90,7 +90,7 @@ export class FunctionsDeployer extends Deployer {
     if (apiKey) {
       this.auth = apiKey;
     } else {
-      const token = this.info.getToken(this.TOKEN_BEARER_KEY, true)?.token;
+      const token = this.info.tokens.get(this.TOKEN_BEARER_KEY, true)?.token;
 
       if (!token) {
         throw new Error('Not authenticated. Please login with `sf login functions`.');

--- a/src/hooks/envDisplay.ts
+++ b/src/hooks/envDisplay.ts
@@ -32,7 +32,7 @@ const hook: SfHook.EnvDisplay<ComputeEnv> = async function (opts) {
   if (apiKey) {
     auth = apiKey;
   } else {
-    const token = info.getToken('functions-bearer', true)?.token;
+    const token = info.tokens.get('functions-bearer', true)?.token;
 
     if (!token) {
       throw new Error('Not authenticated. Please login with `sf login functions`.');

--- a/src/lib/base.ts
+++ b/src/lib/base.ts
@@ -37,7 +37,7 @@ export default abstract class Command extends Base {
   }
 
   protected get username() {
-    return this.info.getToken(Command.TOKEN_BEARER_KEY)?.user;
+    return this.info.tokens.get(Command.TOKEN_BEARER_KEY)?.user;
   }
 
   protected resetClientAuth() {
@@ -52,7 +52,7 @@ export default abstract class Command extends Base {
       if (apiKey) {
         this._auth = apiKey;
       } else {
-        const token = this.info.getToken(Command.TOKEN_BEARER_KEY, true)?.token;
+        const token = this.info.tokens.get(Command.TOKEN_BEARER_KEY, true)?.token;
 
         if (!token) {
           throw new Error(`Not authenticated. Please login with \`${this.config.bin} login functions\`.`);

--- a/test/commands/env/create/compute.test.ts
+++ b/test/commands/env/create/compute.test.ts
@@ -5,8 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { expect, test } from '@oclif/test';
+import { Org, SfdxProject } from '@salesforce/core';
+import { AliasAccessor } from '@salesforce/core/lib/globalInfo';
 import * as sinon from 'sinon';
-import { Org, SfdxProject, Aliases } from '@salesforce/core';
+import { AuthStubs } from '../../../helpers/auth';
 import vacuum from '../../../helpers/vacuum';
 
 const APP_MOCK = {
@@ -101,10 +103,8 @@ describe('sf env create compute', () => {
     .do(() => {
       orgStub = sandbox.stub(Org, 'create' as any).returns(ORG_MOCK);
       sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
-      sandbox.stub(Aliases, 'create' as any).returns({
-        set: aliasSetSpy,
-        write: aliasWriteSpy,
-      });
+      sandbox.stub(AliasAccessor.prototype, 'set' as any).callsFake(aliasSetSpy);
+      AuthStubs.write.callsFake(aliasWriteSpy);
     })
     .finally(() => {
       sandbox.restore();
@@ -132,10 +132,8 @@ describe('sf env create compute', () => {
     .do(() => {
       orgStub = sandbox.stub(Org, 'create' as any).returns(ORG_MOCK);
       sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
-      sandbox.stub(Aliases, 'create' as any).returns({
-        set: aliasSetSpy,
-        write: aliasWriteSpy,
-      });
+      sandbox.stub(AliasAccessor.prototype, 'set' as any).callsFake(aliasSetSpy);
+      AuthStubs.write.callsFake(aliasWriteSpy);
     })
     .finally(() => {
       sandbox.restore();
@@ -198,15 +196,13 @@ describe('sf env create compute', () => {
     });
 
   test
-    .stdout({ print: true })
-    .stderr({ print: true })
+    .stdout()
+    .stderr()
     .retries(3)
     .do(() => {
       sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
-      sandbox.stub(Aliases, 'create' as any).returns({
-        set: aliasSetSpy,
-        write: aliasWriteSpy,
-      });
+      sandbox.stub(AliasAccessor.prototype, 'set' as any).callsFake(aliasSetSpy);
+      AuthStubs.write.callsFake(aliasWriteSpy);
     })
     .add('queryStub', () => {
       const queryStub = sinon.stub();

--- a/test/commands/env/delete.test.ts
+++ b/test/commands/env/delete.test.ts
@@ -5,7 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { expect, test } from '@oclif/test';
-import { Aliases, Org, SfdxProject } from '@salesforce/core';
+import { Org, SfdxProject } from '@salesforce/core';
+import { AliasAccessor } from '@salesforce/core/lib/globalInfo';
 import * as sinon from 'sinon';
 import * as Utils from '../../../src/lib/utils';
 import vacuum from '../../helpers/vacuum';
@@ -60,9 +61,7 @@ describe('env:delete', () => {
     .do(() => {
       sandbox.stub(Utils, 'resolveOrg' as any).returns(ORG_MOCK);
       sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
-      sandbox.stub(Aliases, 'create' as any).returns({
-        get: () => COMPUTE_ENV_NAME,
-      });
+      sandbox.stub(AliasAccessor.prototype, 'get').returns(COMPUTE_ENV_NAME);
     })
     .finally(() => {
       sandbox.restore();
@@ -82,7 +81,7 @@ describe('env:delete', () => {
     .do(() => {
       sandbox
         .stub(Utils, 'resolveOrg' as any)
-        .throws('Attempted to resolve an org without an org ID or defaultusername value');
+        .throws('Attempted to resolve an org without an org ID or target-org value');
     })
     .add('projectResolveStub', () => {
       return sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
@@ -145,9 +144,7 @@ describe('env:delete', () => {
     .do(() => {
       sandbox.stub(Utils, 'resolveOrg' as any).returns(ORG_MOCK);
       sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
-      sandbox.stub(Aliases, 'create' as any).returns({
-        get: () => COMPUTE_ENV_NAME,
-      });
+      sandbox.stub(AliasAccessor.prototype, 'get').returns(COMPUTE_ENV_NAME);
     })
     .finally(() => {
       sandbox.restore();

--- a/test/commands/login/functions.test.ts
+++ b/test/commands/login/functions.test.ts
@@ -17,7 +17,7 @@ describe('sf login functions', () => {
   beforeEach(() => {
     windowOpenStub = sinon.stub();
     AuthStubs.write.callsFake(async function (this: GlobalInfo) {
-      contents = this.getTokens(true);
+      contents = this.tokens.getAll(true);
       return this.getContents();
     });
   });

--- a/test/commands/login/functions/jwt.test.ts
+++ b/test/commands/login/functions/jwt.test.ts
@@ -42,7 +42,7 @@ describe('sf login functions jwt', () => {
 
   beforeEach(() => {
     AuthStubs.write.callsFake(async function (this: GlobalInfo) {
-      contents = this.getTokens(true);
+      contents = this.tokens.getAll(true);
       return this.getContents();
     });
   });

--- a/test/commands/logout/functions.test.ts
+++ b/test/commands/logout/functions.test.ts
@@ -14,7 +14,7 @@ describe('sf logout functions', () => {
 
   beforeEach(() => {
     AuthStubs.write.callsFake(async function (this: GlobalInfo) {
-      contents = this.getTokens(true);
+      contents = this.tokens.getAll(true);
       return this.getContents();
     });
   });

--- a/test/commands/run/function.test.ts
+++ b/test/commands/run/function.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { expect, test } from '@oclif/test';
-import { Config, SfdxPropertyKeys } from '@salesforce/core';
+import { Config, OrgConfigProperties } from '@salesforce/core';
 import { cli } from 'cli-ux';
 
 import { MockTestOrgData, testSetup } from '@salesforce/core/lib/testSetup';
@@ -51,11 +51,13 @@ describe('run:function', () => {
       $$.configStubs.GlobalInfo = { contents: { orgs: { [testData.username]: await testData.getConfig() } } };
 
       const config = await Config.create(Config.getDefaultOptions(true));
-      await config.set(SfdxPropertyKeys.DEFAULT_USERNAME, testData.username);
+      await config.set(OrgConfigProperties.TARGET_ORG, testData.username);
       await config.write();
     });
 
     test
+      .stdout()
+      .stderr()
       .command(['run:function', '-l', targetUrl, '-p', userpayload])
       .it(`Should call the library with payload ${userpayload}`, async () => {
         sinon.assert.calledWith(
@@ -64,6 +66,8 @@ describe('run:function', () => {
         );
       });
     test
+      .stdout()
+      .stderr()
       .command([
         'run:function',
         '-l',
@@ -74,7 +78,7 @@ describe('run:function', () => {
         'TestHeader',
         '--structured',
         '-o',
-        SfdxPropertyKeys.DEFAULT_USERNAME,
+        OrgConfigProperties.TARGET_ORG,
       ])
       .it('Should call the library with all arguments', async () => {
         sinon.assert.calledWith(
@@ -84,14 +88,15 @@ describe('run:function', () => {
             .and(sinon.match.has('function-url', targetUrl))
             .and(sinon.match.has('headers', ['TestHeader']))
             .and(sinon.match.has('structured', true))
-            .and(sinon.match.has('targetusername', SfdxPropertyKeys.DEFAULT_USERNAME))
+            .and(sinon.match.has('targetusername', OrgConfigProperties.TARGET_ORG))
         );
       });
     test
       .stdout()
+      .stderr()
       .command(['run:function', '-l', targetUrl, '-p', userpayload])
-      .it('Should log default username', async (ctx) => {
-        expect(ctx.stdout).to.contain(`Using defaultusername ${testData.username} login credential`);
+      .it('Should log target org', async (ctx) => {
+        expect(ctx.stdout).to.contain(`Using target-org ${testData.username} login credential`);
       });
 
     test
@@ -107,6 +112,7 @@ describe('run:function', () => {
 
     test
       .stdout()
+      .stderr()
       .command(['run:function', '-l', targetUrl, '-p', userpayload])
       .it('Should log response', async (ctx) => {
         expect(ctx.stdout).to.contain('Something happened!');
@@ -130,6 +136,8 @@ describe('run:function', () => {
     });
 
     test
+      .stdout()
+      .stderr()
       .stub(process, 'exit', () => '')
       .command(['run:function', '-l', targetUrl, '-p', userpayload])
       .catch((error) => expect(error.message).to.contain('Something bad happened!'))
@@ -146,6 +154,8 @@ describe('run:function', () => {
     });
 
     test
+      .stdout()
+      .stderr()
       .stub(process, 'exit', () => '')
       .command(['run:function', '-l', targetUrl, '-p', userpayload])
       .catch((error) => expect(error.message).to.contain(errorMessage))
@@ -165,7 +175,7 @@ describe('run:function', () => {
       .command(['run:function', '-l', targetUrl, '-p {"id":12345}'])
       .it('should output the response from the server', (ctx) => {
         expect(ctx.stdout).to.contain('Something happened!');
-        expect(ctx.stderr).to.contain('Warning: No -o connected org or defaultusername found');
+        expect(ctx.stderr).to.contain('Warning: No -o connected org or target-org found');
       });
   });
 });

--- a/test/helpers/auth.ts
+++ b/test/helpers/auth.ts
@@ -6,6 +6,7 @@
  */
 
 import { GlobalInfo } from '@salesforce/core';
+import { TokenAccessor } from '@salesforce/core/lib/globalInfo';
 import { stubMethod } from '@salesforce/ts-sinon';
 import { createSandbox, SinonStub } from 'sinon';
 import NetrcMachine from '../../src/lib/netrc';
@@ -21,7 +22,7 @@ export const AuthStubs: {
 // Run on next tick after mocha is setup
 process.nextTick(() => {
   beforeEach(() => {
-    AuthStubs.getToken = stubMethod(sandbox, GlobalInfo.prototype, 'getToken').returns({
+    AuthStubs.getToken = stubMethod(sandbox, TokenAccessor.prototype, 'get').returns({
       token: 'password',
       user: 'login',
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -911,18 +911,19 @@
     mkdirp "1.0.4"
     sfdx-faye "^1.0.9"
 
-"@salesforce/core@3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.3.1.tgz#0e7ea5742fcbc167542d503bbd618d00142ce016"
-  integrity sha512-UCQ2VYJQthDazGGCaWgQpvpMcgGwaf0NC5d7SL2Qx/Lz9d/C/U7U0OeRBtBrjePodZp/HpEeTnrbGjut+3DaOw==
+"@salesforce/core@3.6.4":
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.6.4.tgz#9c2cf29650325c332788ec81811dc43fe0bfdb45"
+  integrity sha512-BLnNz6xxI2yu4W7PoEKXrmrqAc7iCA6/lgKvOrPfFXRf6nnHA5eNxJ+oU9icgKnPv1/Ls/Fvki92lIXRQlK7BA==
   dependencies:
     "@salesforce/bunyan" "^2.0.0"
     "@salesforce/kit" "^1.5.8"
     "@salesforce/schemas" "^1.0.1"
-    "@salesforce/ts-types" "^1.5.13"
+    "@salesforce/ts-types" "^1.5.20"
     "@types/graceful-fs" "^4.1.5"
     "@types/jsforce" "^1.9.29"
     "@types/mkdirp" "^1.0.1"
+    change-case "^4.1.2"
     debug "^3.1.0"
     graceful-fs "^4.2.4"
     jsen "0.6.6"


### PR DESCRIPTION
### What does this PR do?

Upgrade `@salesforce/core` to the latest version in the 3.x series.

While there are many changes involved in this upgrade, almost all of them are invisible to the end-user with the exception of one: moving from `defaultusername` to `target-org`. This *should* be invisible as well since we really only reference `defaultusername` directly in `run:function` and the new version of the core library translates `defaultusername` lookups to `target-org` lookups, but I felt it was at least worth noting.

### What issues does this PR fix or reference?
@W-9890301@