### PR TITLE
fix: use getValue for aliases instead of get

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@heroku/project-descriptor": "0.0.5",
     "@oclif/core": "0.5.39",
     "@oclif/plugin-not-found": "^1.2.4",
-    "@salesforce/core": "3.6.4",
+    "@salesforce/core": "3.6.5",
     "@salesforce/plugin-org": "^1.6.7",
     "@salesforce/sf-plugins-core": "^0.0.25",
     "@salesforce/ts-sinon": "^1.3.18",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -44,7 +44,7 @@ export async function fetchAppForProject(client: APIClient, projectName: string,
 export async function resolveAppNameForEnvironment(appNameOrAlias: string): Promise<string> {
   // Check if the environment provided is an alias or not, to determine what app name we use to attempt deletion
   const info = await GlobalInfo.getInstance();
-  const matchingAlias = info.aliases.get(appNameOrAlias);
+  const matchingAlias = info.aliases.getValue(appNameOrAlias);
   let appName: string;
   if (matchingAlias) {
     appName = matchingAlias;

--- a/test/commands/env/delete.test.ts
+++ b/test/commands/env/delete.test.ts
@@ -61,7 +61,7 @@ describe('env:delete', () => {
     .do(() => {
       sandbox.stub(Utils, 'resolveOrg' as any).returns(ORG_MOCK);
       sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
-      sandbox.stub(AliasAccessor.prototype, 'get').returns(COMPUTE_ENV_NAME);
+      sandbox.stub(AliasAccessor.prototype, 'getValue').returns(COMPUTE_ENV_NAME);
     })
     .finally(() => {
       sandbox.restore();
@@ -144,7 +144,7 @@ describe('env:delete', () => {
     .do(() => {
       sandbox.stub(Utils, 'resolveOrg' as any).returns(ORG_MOCK);
       sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
-      sandbox.stub(AliasAccessor.prototype, 'get').returns(COMPUTE_ENV_NAME);
+      sandbox.stub(AliasAccessor.prototype, 'getValue').returns(COMPUTE_ENV_NAME);
     })
     .finally(() => {
       sandbox.restore();

--- a/yarn.lock
+++ b/yarn.lock
@@ -911,10 +911,10 @@
     mkdirp "1.0.4"
     sfdx-faye "^1.0.9"
 
-"@salesforce/core@3.6.4":
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.6.4.tgz#9c2cf29650325c332788ec81811dc43fe0bfdb45"
-  integrity sha512-BLnNz6xxI2yu4W7PoEKXrmrqAc7iCA6/lgKvOrPfFXRf6nnHA5eNxJ+oU9icgKnPv1/Ls/Fvki92lIXRQlK7BA==
+"@salesforce/core@3.6.5":
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.6.5.tgz#4c3afa392eb61cd34e2683033c04fbfa4d546850"
+  integrity sha512-EqMZS4Awn/WctCqVWecXOIJKzLUleWw2fvViNP0lVJgt56ZAinZRBetXJFITyKVyslW/WIAhX92NHW7t3AG7Hg==
   dependencies:
     "@salesforce/bunyan" "^2.0.0"
     "@salesforce/kit" "^1.5.8"


### PR DESCRIPTION
### What does this PR do?
This PR bumps the version for `@salesfore/core` to give us access to the `getValue` method on `AliasAccessor`. We were originally using `get` but that doesn't seem to behave like we thought. However, `getValue` does do what we need and will resolve the broken alias lookup.

### What issues does this PR fix or reference?
[skip-validate-pr]