### PR TITLE
chore: bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-functions",
   "description": "Functions plugin for the SF CLI",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "heroku-front-end@salesforce.com",
   "bin": {
     "functions": "./bin/run"
@@ -176,7 +176,7 @@
     "test": "sf-test",
     "test:command-reference": "./bin/dev commandreference:generate --erroronwarnings",
     "test:deprecation-policy": "./bin/dev snapshot:compare",
-    "version": "oclif readme" 
+    "version": "oclif readme"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
### What does this PR do?
bumps the package.json version to sync with npm

### What issues does this PR fix or reference?
[skip-validate-pr]