### PR TITLE
fix: remove plugin-not-found

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@heroku/functions-core": "0.1.3",
     "@heroku/project-descriptor": "0.0.5",
     "@oclif/core": "^1.0.0",
-    "@oclif/plugin-not-found": "^2.2.0",
     "@salesforce/core": "3.6.5",
     "@salesforce/plugin-org": "^1.6.7",
     "@salesforce/sf-plugins-core": "^1.0.0",
@@ -104,9 +103,6 @@
       "sf:env:list": "./lib/hooks/envList",
       "sf:env:display": "./lib/hooks/envDisplay"
     },
-    "plugins": [
-      "@oclif/plugin-not-found"
-    ],
     "devPlugins": [
       "@oclif/plugin-help",
       "@oclif/plugin-which",

--- a/yarn.lock
+++ b/yarn.lock
@@ -856,17 +856,6 @@
     fast-levenshtein "^2.0.6"
     lodash "^4.17.13"
 
-"@oclif/plugin-not-found@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-2.2.0.tgz#400fd862f3c4a1a5f64e610dbb2478bcf83d6ce6"
-  integrity sha512-CdDXDgO0DR60GD+AnjHOscVfZedBMqCJfwl3qknYxvreIXFTatH9pZfPpxy9umla47Mum1J3UOem3ihnmbx7MA==
-  dependencies:
-    "@oclif/color" "^0.x"
-    "@oclif/core" "^0.5.39"
-    cli-ux "^5.6.3"
-    fast-levenshtein "^3.0.0"
-    lodash "^4.17.21"
-
 "@oclif/plugin-warn-if-update-available@^1.5.4":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@oclif/plugin-warn-if-update-available/-/plugin-warn-if-update-available-1.7.0.tgz#5a72abe39ce0b831eb4ae81cb64eb4b9f3ea424a"
@@ -3806,18 +3795,6 @@ fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
-
-fast-levenshtein@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-3.0.0.tgz#37b899ae47e1090e40e3fd2318e4d5f0142ca912"
-  integrity sha512-hKKNajm46uNmTlhHSyZkmToAc56uZJwYq7yrciZjqOxnlfQwERDQJmHPUp7m1m9wx8vgOe8IaCKZ5Kv2k1DdCQ==
-  dependencies:
-    fastest-levenshtein "^1.0.7"
-
-fastest-levenshtein@^1.0.7:
-  version "1.0.12"
-  resolved "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
-  integrity sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==
 
 fastq@^1.6.0:
   version "1.13.0"


### PR DESCRIPTION
### What does this PR do?

Removes the `@oclif/plugin-not-found` plugin since it's already bundled at the CLI level. Having it in the plugin is causing this error in sfdx:

```
✦ function-recipes ➜ sfdx force:org:push
 ›   Warning: forceundefinedorgundefinedpush is not a sfdx command.
```

See [slack discussion](https://salesforce-internal.slack.com/archives/C01LKDT1P6J/p1633643391273600) for more.

### What issues does this PR fix or reference?
[skip-validate-pr]