### PR TITLE
chore: release 1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-functions",
   "description": "Functions plugin for the SF CLI",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": "heroku-front-end@salesforce.com",
   "bin": {
     "functions": "./bin/run"


### PR DESCRIPTION
### What does this PR do?

Bumps the version to 1.3.1. This should release #337 and #310 which both improve the dockerless experience in minor ways.

### What issues does this PR fix or reference?

@W-10379120@