### PR TITLE
fix: update heroku function-core to 0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@heroku-cli/schema": "^1.0.25",
     "@heroku/eventsource": "^1.0.7",
     "@heroku/function-toml": "^0.0.3",
-    "@heroku/functions-core": "0.2.2",
+    "@heroku/functions-core": "0.2.3",
     "@heroku/project-descriptor": "0.0.5",
     "@oclif/core": "^1.0.2",
     "@salesforce/core": "3.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,10 +436,10 @@
     ajv "^6.12.2"
     toml "^3.0.0"
 
-"@heroku/functions-core@0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@heroku/functions-core/-/functions-core-0.2.2.tgz#066a6db9da3edbb5aa2414e83224936e3906af16"
-  integrity sha512-An7GxEJ6wyN4nJu8xUyQBJmel2J3QXlDYzmVsFVDyineHdZ2ACupmW51lA3T7dyZkuOVks96F84NAz1DS7L3wg==
+"@heroku/functions-core@0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@heroku/functions-core/-/functions-core-0.2.3.tgz#f0272b55a82035b65a79e55d6b104f95807e6ea5"
+  integrity sha512-5/yM/u7x3HxOi/MHZT0MHe/RPUq1IGuUDha7uZdGFadQvUsuiZ6evhqAXg7l+mKR/MkyaMTLMLW4VqBgCGhcFw==
   dependencies:
     "@heroku-cli/color" "^1.1.14"
     "@heroku/project-descriptor" "0.0.5"


### PR DESCRIPTION
### What does this PR do?

Update heroku/function-core to 0.2.3 to pick up the release of the new sf-fx-runtime-java v1.0.5

[sf-fx-runtime-java #210](https://github.com/forcedotcom/sf-fx-runtime-java/pull/210)
### What issues does this PR fix or reference?

[W-10397677](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000dGlPhYAK/view)