### PR TITLE
feat: run:function:start defaults to local mode

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -114,6 +114,7 @@
       "debug-port",
       "descriptor",
       "env",
+      "language",
       "network",
       "no-build",
       "no-pull",

--- a/messages/run.function.start.md
+++ b/messages/run.function.start.md
@@ -6,4 +6,58 @@ Build and run a Salesforce Function.
 
 Run this command from the directory of your Salesforce Functions project.
 
-This command will run the target function in a container. In the future, this command will run the target function on the host operating system (locally) instead. If one mode is preferred over the other, consider using the `container` or `local` subcommand instead.
+This command will run the target function locally (on the same operating system as this CLI), just like the `local` subcommand.
+
+Previously, this command ran functions in a container. Container mode is still supported via the `container` subcommand. Arguments relevant to container mode are still accepted, but are deprecated, ignored, and will be dropped in a future release.
+
+# flags.builder.summary
+
+Set custom builder image. Deprecated.
+
+# flags.clear-cache.summary
+
+Clear associated cache before executing. Deprecated.
+
+# flags.debug-port.summary
+
+Port for remote debugging.
+
+# flags.descriptor.summary
+
+Path to project descriptor file (project.toml) that contains function and/or bulid configuration. Deprecated.
+
+# flags.env.summary
+
+Set environment variables (provided during build and run). Deprecated.
+
+# flags.language.summary
+
+The language that the function runs in.
+
+# flags.network.summary
+
+Connect and build containers to a network. This can be useful to build containers which require a local resource. Deprecated.
+
+# flags.no-build.summary
+
+Skip building the an image. Deprecated.
+
+# flags.no-pull.summary
+
+Skip pulling builder image before use. Deprecated.
+
+# flags.no-run.summary
+
+Skip running the built image. Deprecated.
+
+# flags.path.summary
+
+Path to function directory.
+
+# flags.port.summary
+
+Port for running the function.
+
+# flags.verbose.summary
+
+Output additional logs.

--- a/messages/run.function.start.md
+++ b/messages/run.function.start.md
@@ -10,45 +10,9 @@ This command will run the target function locally (on the same operating system 
 
 Previously, this command ran functions in a container. Container mode is still supported via the `container` subcommand. Arguments relevant to container mode are still accepted, but are deprecated, ignored, and will be dropped in a future release.
 
-# flags.builder.summary
-
-Set custom builder image. Deprecated.
-
-# flags.clear-cache.summary
-
-Clear associated cache before executing. Deprecated.
-
-# flags.debug-port.summary
-
-Port for remote debugging.
-
-# flags.descriptor.summary
-
-Path to project descriptor file (project.toml) that contains function and/or bulid configuration. Deprecated.
-
-# flags.env.summary
-
-Set environment variables (provided during build and run). Deprecated.
-
 # flags.language.summary
 
 The language that the function runs in.
-
-# flags.network.summary
-
-Connect and build containers to a network. This can be useful to build containers which require a local resource. Deprecated.
-
-# flags.no-build.summary
-
-Skip building the an image. Deprecated.
-
-# flags.no-pull.summary
-
-Skip pulling builder image before use. Deprecated.
-
-# flags.no-run.summary
-
-Skip running the built image. Deprecated.
 
 # flags.path.summary
 
@@ -58,6 +22,42 @@ Path to function directory.
 
 Port for running the function.
 
+# flags.debug-port.summary
+
+Port for remote debugging.
+
 # flags.verbose.summary
 
 Output additional logs.
+
+# flags.builder.deprecation
+
+--builder is deprecated and will be removed in a future release. Please discontinue use of this flag or use the `container` subcommand instead.
+
+# flags.clear-cache.deprecation
+
+--clear-cache is deprecated and will be removed in a future release. Please discontinue use of this flag or use the `container` subcommand instead.
+
+# flags.descriptor.deprecation
+
+--descriptor is deprecated and will be removed in a future release. Please discontinue use of this flag or use the `container` subcommand instead.
+
+# flags.env.deprecation
+
+--descriptor is deprecated and will be removed in a future release. Please discontinue use of this flag or use the `container` subcommand instead.
+
+# flags.network.deprecation
+
+--network is deprecated and will be removed in a future release. Please discontinue use of this flag or use the `container` subcommand instead.
+
+# flags.no-build.deprecation
+
+--no-build is deprecated and will be removed in a future release. Please discontinue use of this flag or use the `container` subcommand instead.
+
+# flags.no-pull.deprecation
+
+--no-pull is deprecated and will be removed in a future release. Please discontinue use of this flag or use the `container` subcommand instead.
+
+# flags.no-run.deprecation
+
+--no-run is deprecated and will be removed in a future release. Please discontinue use of this flag or use the `container` subcommand instead.

--- a/messages/run.function.start.md
+++ b/messages/run.function.start.md
@@ -44,7 +44,7 @@ Output additional logs.
 
 # flags.env.deprecation
 
---descriptor is deprecated and will be removed in a future release. Please discontinue use of this flag or use the `container` subcommand instead.
+--env is deprecated and will be removed in a future release. Please discontinue use of this flag or use the `container` subcommand instead.
 
 # flags.network.deprecation
 

--- a/src/commands/run/function/start.ts
+++ b/src/commands/run/function/start.ts
@@ -5,14 +5,78 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import * as path from 'path';
 import { Messages } from '@salesforce/core';
-import Container from './start/container';
+import { Flags } from '@oclif/core';
+import Local from './start/local';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-functions', 'run.function.start');
 
-// run:function:start is an alias to run:function:start:container
-export default class Start extends Container {
+// run:function:start is an alias to run:function:start:local.
+// run:function:start previously ran via container mode, so it accepts
+// arguments applicable to the container subcommand, but ignores them and flags
+// them as deprecated. The additional flags may be removed after 04/30/2022.
+export default class Start extends Local {
   static summary = messages.getMessage('summary');
+
   static description = messages.getMessage('description');
+
+  static flags = {
+    builder: Flags.string({
+      description: messages.getMessage('flags.builder.summary'),
+      hidden: true,
+    }),
+    'clear-cache': Flags.boolean({
+      description: messages.getMessage('flags.clear-cache.summary'),
+    }),
+    'debug-port': Flags.integer({
+      char: 'b',
+      description: messages.getMessage('flags.debug-port.summary'),
+      default: 9229,
+    }),
+    descriptor: Flags.string({
+      description: messages.getMessage('flags.descriptor.summary'),
+      hidden: true,
+    }),
+    env: Flags.string({
+      char: 'e',
+      description: messages.getMessage('flags.env.summary'),
+      multiple: true,
+    }),
+    language: Flags.enum({
+      options: ['javascript', 'typescript', 'java', 'auto'],
+      description: messages.getMessage('flags.language.summary'),
+      char: 'l',
+      default: 'auto',
+    }),
+    network: Flags.string({
+      description: messages.getMessage('flags.network.summary'),
+    }),
+    'no-build': Flags.boolean({
+      description: messages.getMessage('flags.no-build.summary'),
+      hidden: true,
+    }),
+    'no-pull': Flags.boolean({
+      description: messages.getMessage('flags.no-pull.summary'),
+    }),
+    'no-run': Flags.boolean({
+      description: messages.getMessage('flags.no-run.summary'),
+      hidden: true,
+    }),
+    path: Flags.string({
+      description: messages.getMessage('flags.path.summary'),
+      default: path.resolve('.'),
+      hidden: true,
+    }),
+    port: Flags.integer({
+      char: 'p',
+      description: messages.getMessage('flags.port.summary'),
+      default: 8080,
+    }),
+    verbose: Flags.boolean({
+      char: 'v',
+      description: messages.getMessage('flags.verbose.summary'),
+    }),
+  };
 }

--- a/src/commands/run/function/start.ts
+++ b/src/commands/run/function/start.ts
@@ -29,6 +29,7 @@ export default class Start extends Local {
     }),
     'clear-cache': Flags.boolean({
       description: messages.getMessage('flags.clear-cache.summary'),
+      hidden: true,
     }),
     'debug-port': Flags.integer({
       char: 'b',
@@ -43,6 +44,7 @@ export default class Start extends Local {
       char: 'e',
       description: messages.getMessage('flags.env.summary'),
       multiple: true,
+      hidden: true,
     }),
     language: Flags.enum({
       options: ['javascript', 'typescript', 'java', 'auto'],
@@ -52,6 +54,7 @@ export default class Start extends Local {
     }),
     network: Flags.string({
       description: messages.getMessage('flags.network.summary'),
+      hidden: true,
     }),
     'no-build': Flags.boolean({
       description: messages.getMessage('flags.no-build.summary'),
@@ -59,6 +62,7 @@ export default class Start extends Local {
     }),
     'no-pull': Flags.boolean({
       description: messages.getMessage('flags.no-pull.summary'),
+      hidden: true,
     }),
     'no-run': Flags.boolean({
       description: messages.getMessage('flags.no-run.summary'),

--- a/src/commands/run/function/start.ts
+++ b/src/commands/run/function/start.ts
@@ -7,17 +7,19 @@
 
 import * as path from 'path';
 import { Messages } from '@salesforce/core';
-import { Command, Flags } from '@oclif/core';
+import { Flags } from '@oclif/core';
 import { LocalRun } from '@heroku/functions-core';
+
+import Local from './start/local';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-functions', 'run.function.start');
 
-// run:function:start is a synonym command to run:function:start:local.
-// run:function:start previously ran via container mode, so it accepts
+// run:function:start is an alias command to run:function:start:local.
+// run:function:start previously ran via container mode, so it still accepts
 // arguments applicable to the container subcommand, but ignores them and flags
 // them as deprecated. The additional flags may be removed after 04/30/2022.
-export default class Start extends Command {
+export default class Start extends Local {
   static summary = messages.getMessage('summary');
 
   static description = messages.getMessage('description');
@@ -88,11 +90,6 @@ export default class Start extends Command {
         // No deprecation message, flag is not deprecated
       }
     });
-    const localRun = new LocalRun(flags.language, {
-      path: flags.path,
-      port: flags.port,
-      debugPort: flags['debug-port'],
-    });
-    await localRun.exec();
+    await this.runWithFlags(flags);
   }
 }

--- a/src/commands/run/function/start/local.ts
+++ b/src/commands/run/function/start/local.ts
@@ -43,6 +43,12 @@ export default class Local extends Command {
 
   async run() {
     const { flags } = await this.parse(Local);
+    await this.runWithFlags(flags);
+  }
+
+  async runWithFlags(
+    flags: { path: string; port: number; 'debug-port': number; language: string } & { json: boolean | undefined }
+  ) {
     const localRun = new LocalRun(flags.language, {
       path: flags.path,
       port: flags.port,

--- a/test/commands/run/function/start.test.ts
+++ b/test/commands/run/function/start.test.ts
@@ -4,33 +4,46 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { test } from '@oclif/test';
+import { expect, test } from '@oclif/test';
 import * as sinon from 'sinon';
+import { LocalRun } from '@heroku/functions-core';
 
-import * as library from '@heroku/functions-core';
-import { Benny } from '@heroku/functions-core';
-
-describe('function:start', () => {
+describe('run:function:start', () => {
   let sandbox: sinon.SinonSandbox;
-  let bennyRunStub: sinon.SinonStub;
-  let bennyBuildStub: sinon.SinonStub;
+  let localRunExecStub: sinon.SinonStub;
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    bennyRunStub = sandbox.stub(Benny.prototype, 'run');
-    bennyBuildStub = sandbox.stub(Benny.prototype, 'build');
-    bennyRunStub.returns(true);
-    bennyBuildStub.returns(true);
-    sandbox
-      .stub(library, 'getProjectDescriptor')
-      .returns(Promise.resolve({ com: { salesforce: { id: 'allthethingsfunction' } } }));
+    localRunExecStub = sandbox.stub(LocalRun.prototype, 'exec');
+    localRunExecStub.resolves();
   });
 
   afterEach(() => {
     sandbox.restore();
   });
 
-  test.command(['run:function:start']).it('Should call the library methods', async () => {
-    sinon.assert.calledOnce(bennyBuildStub);
-    sinon.assert.calledOnce(bennyRunStub);
+  test.command(['run:function:start']).it('Should call LocalRun.exec', async () => {
+    sinon.assert.calledOnce(localRunExecStub);
+  });
+
+  ['--builder', '--network', '--env'].forEach((deprecatedArg) => {
+    describe(`with deprecated arg ${deprecatedArg}`, () => {
+      test
+        .stderr()
+        .command(['run:function:start', deprecatedArg, 'some:val'])
+        .it('will include a deprecation notice', (ctx) => {
+          expect(ctx.stderr).to.contain(`${deprecatedArg} is deprecated`);
+        });
+    });
+  });
+
+  ['--no-pull', '--no-run', '--no-build'].forEach((deprecatedArg) => {
+    describe(`with deprecated flag ${deprecatedArg}`, () => {
+      test
+        .stderr()
+        .command(['run:function:start', deprecatedArg])
+        .it('will include a deprecation notice', (ctx) => {
+          expect(ctx.stderr).to.contain(`${deprecatedArg} is deprecated`);
+        });
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?

This changes `sf run function start` to behave like `sf run function start local` ("Dockerless"/local mode) instead of behaving like `sf run function start container` (Docker/container mode) as it does today. 

With this PR `sf run function start` behaves identically to `sf run function start local`, with the exception that it still accepts the flags relevant to `sf run function start container`. Those flags (`--builder`, `--network`, `--no-pull`, etc.) are not relevant in local mode, so are accepted, but flagged as deprecated in help and in warning messages.

For more context on why we're doing this and the plan of execution see: https://salesforce.quip.com/CnpKAFNnfZBC

### What issues does this PR fix or reference?

[W-10409382](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00000e18skYAA)
