### PR TITLE
chore: fix windows package testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ workflows:
                 - maintenance
             exclude:
               - os: windows
-                node_version: lts
+                node_version: latest
               - os: windows
                 node_version: maintenance
       - release-management/test-plugin-inclusion:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-functions",
   "description": "Functions plugin for the SF CLI",
-  "version": "1.5.3",
+  "version": "1.5.0",
   "author": "heroku-front-end@salesforce.com",
   "bin": {
     "functions": "./bin/run"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-functions",
   "description": "Functions plugin for the SF CLI",
-  "version": "1.4.3",
+  "version": "1.5.3",
   "author": "heroku-front-end@salesforce.com",
   "bin": {
     "functions": "./bin/run"


### PR DESCRIPTION
### What does this PR do?

Our [latest release](https://circleci.com/gh/salesforcecli/plugin-functions/7146?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) has failed with this error:

<img width="1186" alt="Screen Shot 2022-01-19 at 11 03 21 AM" src="https://user-images.githubusercontent.com/917672/150181765-22a3ee88-4677-4c92-83fe-ee388e68a9cd.png">

This is due to an upstream bug in npm: https://github.com/npm/cli/issues/4234.

According to https://salesforce-internal.slack.com/archives/C01LKDT1P6J/p1642612210084100, this issue does not occur with LTS node releases.

This PR changes the `release-management/test-package` Circle job to use windows/LTS instead of windows/latest, which should allow our release automation to work again. 

This PR also bumps the minor version, since the automation failed on https://github.com/salesforcecli/plugin-functions/commit/a2bd50c950cd9fe4f77bd6e6f3d662a977b9946c.

### What issues does this PR fix or reference?

[@W-10409382@](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00000e18skYAA)
