### PR TITLE
feat: com.salesforce.salesforce-api-version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@heroku-cli/schema": "^1.0.25",
     "@heroku/eventsource": "^1.0.7",
     "@heroku/function-toml": "^0.0.3",
-    "@heroku/functions-core": "0.2.3",
+    "@heroku/functions-core": "0.2.5",
     "@heroku/project-descriptor": "0.0.5",
     "@oclif/core": "^1.0.2",
     "@salesforce/core": "3.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,26 +436,24 @@
     ajv "^6.12.2"
     toml "^3.0.0"
 
-"@heroku/functions-core@0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@heroku/functions-core/-/functions-core-0.2.3.tgz#f0272b55a82035b65a79e55d6b104f95807e6ea5"
-  integrity sha512-5/yM/u7x3HxOi/MHZT0MHe/RPUq1IGuUDha7uZdGFadQvUsuiZ6evhqAXg7l+mKR/MkyaMTLMLW4VqBgCGhcFw==
+"@heroku/functions-core@0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@heroku/functions-core/-/functions-core-0.2.5.tgz#1119fd19830a5a23f0004727f119420079e2ab0a"
+  integrity sha512-0NG0X1hcVs+fNus71FsGiRetxjDZitb41K0wOkgP0kjmnzHtahUeaoZuI8jgJUTYfm22TGeKc6lxkwAklI2MDg==
   dependencies:
     "@heroku-cli/color" "^1.1.14"
     "@heroku/project-descriptor" "0.0.5"
     "@salesforce/core" "^2.20.10"
     "@salesforce/templates" "^52.0.0"
     "@salesforce/ts-sinon" "^1.3.12"
-    "@types/chai-as-promised" "^7.1.4"
     axios "^0.21.2"
-    chai-as-promised "^7.1.1"
     cloudevents "^4.0.2"
     fs-extra "^9.1.0"
     global-agent "^2.1.8"
     handlebars "^4.7.7"
     mem-fs "^1.2.0 || ^2.0.0"
     mem-fs-editor "^8.1.2 || ^9.0.0"
-    node-fetch "^2.6.1"
+    node-fetch "^2.6.7"
     openpgp "^5.0.0"
     semver "^7.3.5"
     sha256-file "^1.0.0"
@@ -1406,13 +1404,6 @@
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
   integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
-
-"@types/chai-as-promised@^7.1.4":
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.4.tgz#caf64e76fb056b8c8ced4b761ed499272b737601"
-  integrity sha512-1y3L1cHePcIm5vXkh1DSGf/zQq5n5xDKG1fpCvf18+uOkpce0Z1ozNFPkyWsVswK7ntN1sZBw3oU6gmN+pDUcA==
-  dependencies:
-    "@types/chai" "*"
 
 "@types/chai@*", "@types/chai@^4.2.11":
   version "4.2.19"
@@ -2438,13 +2429,6 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
-
-chai-as-promised@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
-  integrity sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==
-  dependencies:
-    check-error "^1.0.2"
 
 chai@^4.2.0:
   version "4.3.6"


### PR DESCRIPTION
### What does this PR do?

Adds support for com.salesforce.salesforce.api-version by updating to the latest version of `@heroku/functions-core`. The latest version includes these changes: https://github.com/heroku/sf-functions-core/pull/37, https://github.com/heroku/sf-functions-core/pull/36. Both target the introduction of `com.salesforce.salesforce-api-version` in a function's `project.toml`. More details can be found in our feature document: https://salesforce.quip.com/auYwAHFJLoNy.

### What issues does this PR fix or reference?

@[W-10679434](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00000n8Y8mYAE)@
@[W-10474584](https://gus.my.salesforce.com/a07EE00000htVsBYAU)@