### PR TITLE
fix: add help text for run function start --language

### DIFF
--- a/src/commands/run/function/start.ts
+++ b/src/commands/run/function/start.ts
@@ -45,6 +45,7 @@ export default class Start extends Local {
       hidden: true,
     }),
     language: Flags.enum({
+      description: messages.getMessage('flags.language.summary'),
       options: ['javascript', 'typescript', 'java', 'auto'],
       char: 'l',
       default: 'auto',


### PR DESCRIPTION
### What does this PR do?

Adds missing help text for the `--language` flag for `sf run function start`

### What issues does this PR fix or reference?
@[W-10466337](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00000h8F1HYAU)@