### PR TITLE
fix: update functions-core to 0.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@heroku-cli/schema": "^1.0.25",
     "@heroku/eventsource": "^1.0.7",
     "@heroku/function-toml": "^0.0.3",
-    "@heroku/functions-core": "0.2.5",
+    "@heroku/functions-core": "0.2.6",
     "@heroku/project-descriptor": "0.0.5",
     "@oclif/core": "^1.0.2",
     "@salesforce/core": "3.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,10 +436,10 @@
     ajv "^6.12.2"
     toml "^3.0.0"
 
-"@heroku/functions-core@0.2.5":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@heroku/functions-core/-/functions-core-0.2.5.tgz#1119fd19830a5a23f0004727f119420079e2ab0a"
-  integrity sha512-0NG0X1hcVs+fNus71FsGiRetxjDZitb41K0wOkgP0kjmnzHtahUeaoZuI8jgJUTYfm22TGeKc6lxkwAklI2MDg==
+"@heroku/functions-core@0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@heroku/functions-core/-/functions-core-0.2.6.tgz#48294dfd077cf99d8b247b38d4309b37c24b3dd3"
+  integrity sha512-9BoCs5ruOXBvneqQVRfTCXTlxnBo9coAOKtXUS5KO/sJfu3AUr94sDyNCPSOr3dZEb44s2IsdnSe2JI+1gjSwg==
   dependencies:
     "@heroku-cli/color" "^1.1.14"
     "@heroku/project-descriptor" "0.0.5"


### PR DESCRIPTION
### What does this PR do?

Bumps @heroku/functions-core to 0.2.6, which updates sf-fx-runtime-nodejs to 0.11.0. The primary change included in this release is https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/294, which improves error messaging for function local development.

### What issues does this PR fix or reference?

[GUS-W-10728741](https://gus.my.salesforce.com/a07EE00000qUu23YAC)
