### PR TITLE
feat: Add sf create compute collaborator add command cla missing fixed

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -12,6 +12,12 @@
     "alias": []
   },
   {
+    "command": "env:compute:collaborator:add",
+    "plugin": "@salesforce/plugin-functions",
+    "flags": ["heroku-user"],
+    "alias": []
+  },
+  {
     "command": "env:delete",
     "plugin": "@salesforce/plugin-functions",
     "flags": ["confirm", "environment", "target-compute"],

--- a/messages/env.compute.collaborator.add.md
+++ b/messages/env.compute.collaborator.add.md
@@ -6,7 +6,7 @@ Add a Heroku user as a collaborator on this Functions account, allowing them to 
 
 - Add a Heroku user as a collaborator on this Functions account.
 
-  <%= config.bin %> <%= command.id %> --heroku-user heroku-email
+  <%= config.bin %> <%= command.id %> --heroku-user example@heroku.com
 
 # flags.heroku-user.summary
 

--- a/messages/env.compute.collaborator.add.md
+++ b/messages/env.compute.collaborator.add.md
@@ -1,12 +1,12 @@
 # summary
 
-Add a Heroku user as a collaborator on compute environments, allowing them to attach add-ons.
+Add a Heroku user as a collaborator on this Functions account, allowing them to attach Heroku add-ons to compute environments.
 
 # examples
 
-- Add a Heroku user to all compute environments:
+- Add a Heroku user as a collaborator on this Functions account.
 
-  <%= config.bin %> <%= command.id %> --heroku-user heroku-user
+  <%= config.bin %> <%= command.id %> --heroku-user heroku-email
 
 # flags.heroku-user.summary
 

--- a/messages/env.compute.collaborator.add.md
+++ b/messages/env.compute.collaborator.add.md
@@ -1,0 +1,13 @@
+# summary
+
+Add a Heroku user as a collaborator on compute environments, allowing them to attach add-ons.
+
+# examples
+
+- Add a Heroku user to all compute environments:
+
+  <%= config.bin %> <%= command.id %> --heroku-user heroku-user
+
+# flags.heroku-user.summary
+
+Email address of the Heroku user you're adding as a collaborator.

--- a/src/commands/env/compute/collaborator/add.ts
+++ b/src/commands/env/compute/collaborator/add.ts
@@ -69,6 +69,6 @@ export default class ComputeCollaboratorAdd extends Command {
     }
 
     cli.action.stop();
-    this.log('For more information about attaching add-ons to your Functions, run $ heroku addons:attach --help.');
+    this.log('For more information about attaching Heroku add-ons to your compute environments, run $ heroku addons:attach --help.');
   }
 }

--- a/src/commands/env/compute/collaborator/add.ts
+++ b/src/commands/env/compute/collaborator/add.ts
@@ -35,7 +35,7 @@ export default class ComputeCollaboratorAdd extends Command {
     if (!herokuUser) {
       throw new Errors.CLIError(
         `Missing required flag:
-        -h, --heroku-user heroku-email  ${herokuColor.dim('Heroku user email address.')}
+        -h, --heroku-user example@heroku.com  ${herokuColor.dim('Heroku user email address.')}
        See more help with --help`
       );
     }

--- a/src/commands/env/compute/collaborator/add.ts
+++ b/src/commands/env/compute/collaborator/add.ts
@@ -35,7 +35,7 @@ export default class ComputeCollaboratorAdd extends Command {
     if (!herokuUser) {
       throw new Errors.CLIError(
         `Missing required flag:
-        -c, --heroku-user heroku-user  ${herokuColor.dim('Heroku user email address.')}
+        -c, --heroku-user heroku-email  ${herokuColor.dim('Heroku user email address.')}
        See more help with --help`
       );
     }

--- a/src/commands/env/compute/collaborator/add.ts
+++ b/src/commands/env/compute/collaborator/add.ts
@@ -35,7 +35,7 @@ export default class ComputeCollaboratorAdd extends Command {
     if (!herokuUser) {
       throw new Errors.CLIError(
         `Missing required flag:
-        -c, --heroku-user heroku-email  ${herokuColor.dim('Heroku user email address.')}
+        -h, --heroku-user heroku-email  ${herokuColor.dim('Heroku user email address.')}
        See more help with --help`
       );
     }
@@ -43,10 +43,6 @@ export default class ComputeCollaboratorAdd extends Command {
     cli.action.start(
       `Adding Heroku user ${herokuColor.heroku(herokuUser)} as a collaborator on this Functions account`
     );
-
-    cli.action.stop();
-
-    this.log('For more information about attaching add-ons to your Functions, see Addons:Attach.');
 
     try {
       await this.client.post<Heroku.Collaborator>('/salesforce-orgs/collaborators', {
@@ -73,5 +69,6 @@ export default class ComputeCollaboratorAdd extends Command {
     }
 
     cli.action.stop();
+    this.log('For more information about attaching add-ons to your Functions, run $ heroku addons:attach --help.');
   }
 }

--- a/src/commands/env/compute/collaborator/add.ts
+++ b/src/commands/env/compute/collaborator/add.ts
@@ -69,6 +69,8 @@ export default class ComputeCollaboratorAdd extends Command {
     }
 
     cli.action.stop();
-    this.log('For more information about attaching Heroku add-ons to your compute environments, run $ heroku addons:attach --help.');
+    this.log(
+      'For more information about attaching Heroku add-ons to your compute environments, run $ heroku addons:attach --help.'
+    );
   }
 }

--- a/src/commands/env/compute/collaborator/add.ts
+++ b/src/commands/env/compute/collaborator/add.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import herokuColor from '@heroku-cli/color';
+import * as Heroku from '@heroku-cli/schema';
+import { Errors, Flags } from '@oclif/core';
+import { cli } from 'cli-ux';
+import { Messages } from '@salesforce/core';
+import { FunctionsFlagBuilder } from '../../../../lib/flags';
+import Command from '../../../../lib/base';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-functions', 'env.compute.collaborator.add');
+
+export default class ComputeCollaboratorAdd extends Command {
+  static summary = messages.getMessage('summary');
+
+  static examples = messages.getMessages('examples');
+
+  static flags = {
+    'heroku-user': FunctionsFlagBuilder.environment({
+      char: 'h',
+      description: messages.getMessage('flags.heroku-user.summary'),
+      required: true,
+    }),
+  };
+
+  async run() {
+    const { flags } = await this.parse(ComputeCollaboratorAdd);
+    const herokuUser = flags['heroku-user'];
+
+    if (!herokuUser) {
+      throw new Errors.CLIError(
+        `Missing required flag:
+        -c, --heroku-user heroku-user  ${herokuColor.dim('Heroku user email address.')}
+       See more help with --help`
+      );
+    }
+
+    cli.action.start(
+      `Adding Heroku user ${herokuColor.heroku(herokuUser)} as a collaborator on this Functions account`
+    );
+
+    cli.action.stop();
+
+    this.log('For more information about attaching add-ons to your Functions, see Addons:Attach.');
+
+    try {
+      await this.client.post<Heroku.Collaborator>('/salesforce-orgs/collaborators', {
+        headers: {
+          Accept: 'application/vnd.heroku+json; version=3.evergreen',
+          Authorization: `Bearer ${this.auth}`,
+        },
+        data: {
+          user: herokuUser,
+        },
+      });
+    } catch (e) {
+      const error = e as Error;
+
+      if (error.message?.includes('409')) {
+        this.error(`${herokuColor.heroku(herokuUser)} is already a collaborator to this Functions account.`);
+      }
+
+      if (error.message?.includes('404')) {
+        this.error(`${herokuColor.heroku(herokuUser)} does not exist.`);
+      }
+
+      this.error(error.message);
+    }
+
+    cli.action.stop();
+  }
+}

--- a/test/commands/env/compute/collaborator/add.test.ts
+++ b/test/commands/env/compute/collaborator/add.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { expect, test } from '@oclif/test';
+import herokuColor from '@heroku-cli/color';
+
+const HEROKU_USER = 'rick@morty.com';
+
+describe('sf env compute collaborator add', () => {
+  test
+    .stdout()
+    .stderr()
+    .nock('https://api.heroku.com', (api) => api.post('/salesforce-orgs/collaborators').reply(409, {}))
+    .command(['env:compute:collaborator:add', '-h', HEROKU_USER])
+    .catch((error) => {
+      expect(error.message).contains(
+        `${herokuColor.heroku(HEROKU_USER)} is already a collaborator to this Functions account.`
+      );
+    })
+    .it('alerts user if they already have a specifc user added');
+
+  test
+    .stdout()
+    .stderr()
+    .nock('https://api.heroku.com', (api) => api.post('/salesforce-orgs/collaborators').reply(200, {}))
+    .command(['env:compute:collaborator:add', '-h', HEROKU_USER])
+    .it('connects heroku user to compute environments', (ctx) => {
+      expect(ctx.stderr).to.contain(
+        `Adding Heroku user ${herokuColor.heroku(HEROKU_USER)} as a collaborator on this Functions account`
+      );
+    });
+
+  test
+    .stdout()
+    .stderr()
+    .nock('https://api.heroku.com', (api) => api.post('/salesforce-orgs/collaborators').reply(404, {}))
+    .command(['env:compute:collaborator:add', '-h', HEROKU_USER])
+    .catch((error) => {
+      expect(error.message).contains(`${herokuColor.heroku(HEROKU_USER)} does not exist.`);
+    })
+    .it('alerts user if user entered does not exist');
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -8684,16 +8684,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shelljs@^0.8.3, shelljs@^0.8.4, shelljs@~0.8.4:
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
-  integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
-
-shelljs@^0.8.5:
+shelljs@^0.8.3, shelljs@^0.8.4, shelljs@^0.8.5, shelljs@~0.8.4:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
   integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
@@ -8703,12 +8694,12 @@ shelljs@^0.8.5:
     rechoir "^0.6.2"
 
 shx@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/shx/-/shx-0.3.3.tgz#681a88c7c10db15abe18525349ed474f0f1e7b9f"
-  integrity sha512-nZJ3HFWVoTSyyB+evEKjJ1STiixGztlqwKLTUNV5KqMWtGey9fTd4KU1gdZ1X9BV6215pswQ/Jew9NsuS/fNDA==
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/shx/-/shx-0.3.4.tgz#74289230b4b663979167f94e1935901406e40f02"
+  integrity sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==
   dependencies:
     minimist "^1.2.3"
-    shelljs "^0.8.4"
+    shelljs "^0.8.5"
 
 side-channel@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
### IMPORTANT NOTE

This PR is the updated version of [this PR](https://github.com/salesforcecli/plugin-functions/pull/364). See back to old PR for previous conversation notes.

### What does this PR do?
Adds a heroku user to the the functions via cli. This enables users to use any of their compute environments
with heroku addons.

## How to verify?
1. Pull down the PR branch
2. Enable the feature flag `heroku sudo labs:enable allow-functions-collab --user username@heroku.com`
2. Make sure that you have your scratch org, dev hub, compute environments all setup
3. Attach the compute environment to one of your databases locally by running this command from within the branch directory `sf env compute collaborator add --heroku-user:HEROKU_USER`
4. Check to see if you received an email like this

<img width="510" alt="Screen Shot 2022-02-24 at 9 17 11 AM" src="https://user-images.githubusercontent.com/22944735/155575676-72b483c1-5b07-4924-b9e9-5438e03c1a49.png">

5. Try and add yourself again and see if you get this error
`Collaborator <heroku-user> has already been added.`
6. Try and add a heroku user account that doesn't exist and see if you get this error
`There is no Heroku User under the username <heroku-user>.`
7. Try and add a heroku user without the `-h` flag and see if you get this error
`Missing required flag: -c, --heroku-user heroku-user  <heroku-user> See more help with --help`

