### PR TITLE
add --json flag on env, deploy, logout and run cmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,38 @@ Now you should be able to run functions commands, e.g. `sf generate project`, `s
 
 ## `sf deploy functions`
 
+Deploy a Salesforce Function to an org from your local project.
+
 ```
 USAGE
-  $ sf deploy functions -o <value> [-b <value>] [--force] [-q]
+  $ sf deploy functions -o <value> [-b <value>] [--force] [-q] [-j]
 
 FLAGS
   -b, --branch=<value>         Deploy the latest commit from a branch different from the currently active branch.
+  -j, --json                   Output list in JSON format.
   -o, --connected-org=<value>  (required) Username or alias for the org that the compute environment should be connected
                                to.
   -q, --quiet                  Limit the amount of output displayed from the deploy process.
   --force                      Ignore warnings and overwrite remote repository (not allowed in production).
+
+DESCRIPTION
+  Deploy a Salesforce Function to an org from your local project.
+
+  You must run this command from within a git repository. Only committed changes to Functions are deployed. The active
+  branch is deployed unless specified otherwise with `--branch`.
+
+EXAMPLES
+  Deploy a Salesforce Function:
+
+    $ sf deploy functions --connected-org org-alias
+
+  Deploy to 'deploy-branch':
+
+    $ sf deploy functions --connected-org org-alias --branch deploy-branch
+
+  Overwrite the remote repository:
+
+    $ sf deploy functions --connected-org org-alias --force
 ```
 
 ## `sf env compute collaborator add`
@@ -88,10 +110,11 @@ Create a compute environment for use with Salesforce Functions.
 
 ```
 USAGE
-  $ sf env create compute [-o <value>] [-a <value>]
+  $ sf env create compute [-o <value>] [-a <value>] [-j]
 
 FLAGS
   -a, --alias=<value>          Alias for the created environment.
+  -j, --json                   Output list in JSON format.
   -o, --connected-org=<value>  Username or alias for the org that the compute environment should be connected to.
 
 DESCRIPTION
@@ -121,10 +144,11 @@ Delete an environment.
 
 ```
 USAGE
-  $ sf env delete [-e <value> | ] [--confirm <value>]
+  $ sf env delete [-e <value> | ] [--confirm <value>] [-j]
 
 FLAGS
   -e, --target-compute=<value>  Environment name.
+  -j, --json                    Output list in JSON format.
   --confirm=name...             Confirmation name.
 
 DESCRIPTION
@@ -187,10 +211,11 @@ Add log drain to a specified environment.
 
 ```
 USAGE
-  $ sf env logdrain add [-e <value> | ] [-l <value> | ]
+  $ sf env logdrain add [-e <value> | ] [-l <value> | ] [-j]
 
 FLAGS
   -e, --target-compute=<value>  Environment name.
+  -j, --json                    Output list in JSON format.
   -l, --drain-url=<value>       Endpoint that will receive sent logs.
 
 DESCRIPTION
@@ -233,10 +258,11 @@ Remove log drain from a specified environment.
 
 ```
 USAGE
-  $ sf env logdrain remove [-e <value> | ] [-l <value> | ]
+  $ sf env logdrain remove [-e <value> | ] [-l <value> | ] [-j]
 
 FLAGS
   -e, --target-compute=<value>  Environment name.
+  -j, --json                    Output list in JSON format.
   -l, --drain-url=<value>       Log drain url to remove.
 
 DESCRIPTION
@@ -306,10 +332,11 @@ Set a single config value for an environment.
 
 ```
 USAGE
-  $ sf env var set [-e <value> | ]
+  $ sf env var set [-e <value> | ] [-j]
 
 FLAGS
   -e, --target-compute=<value>  Environment name.
+  -j, --json                    Output list in JSON format.
 
 EXAMPLES
   Set a config value:
@@ -323,10 +350,11 @@ Unset a single config value for an environment.
 
 ```
 USAGE
-  $ sf env var unset [-e <value> | ]
+  $ sf env var unset [-e <value> | ] [-j]
 
 FLAGS
   -e, --target-compute=<value>  Environment name.
+  -j, --json                    Output list in JSON format.
 
 DESCRIPTION
   Unset a single config value for an environment.
@@ -387,17 +415,17 @@ Login using JWT instead of default web-based flow. This will authenticate you wi
 
 ```
 USAGE
-  $ sf login functions jwt -u <value> -f <value> -i <value> [-l <value> | ] [--json] [-a <value>] [-d] [-v]
+  $ sf login functions jwt -u <value> -f <value> -i <value> [-l <value> | ] [-j] [-a <value>] [-d] [-v]
 
 FLAGS
   -a, --alias=<value>         Alias for the org.
   -d, --set-default           Set the org as the default that all org-related commands run against.
   -f, --keyfile=<value>       (required) Path to JWT keyfile.
   -i, --clientid=<value>      (required) OAuth client ID.
+  -j, --json                  Output list in JSON format.
   -l, --instance-url=<value>  The login URL of the instance the org lives on.
   -u, --username=<value>      (required) Authentication username.
   -v, --set-default-dev-hub   Set the org as the default Dev Hub for scratch org creation.
-  --json                      Format output as JSON.
 
 DESCRIPTION
   Login using JWT instead of default web-based flow. This will authenticate you with both sf and Salesforce Functions.
@@ -421,7 +449,10 @@ Log out of your Salesforce Functions account.
 
 ```
 USAGE
-  $ sf logout functions
+  $ sf logout functions [-j]
+
+FLAGS
+  -j, --json  Output list in JSON format.
 
 EXAMPLES
   Log out:
@@ -435,10 +466,11 @@ Send a cloudevent to a function.
 
 ```
 USAGE
-  $ sf run function [-l <value> | ] [-H <value>] [-p <value>] [-s] [-o <value>]
+  $ sf run function [-l <value> | ] [-H <value>] [-p <value>] [-s] [-o <value>] [-j]
 
 FLAGS
   -H, --headers=<value>...     Set headers.
+  -j, --json                   Output list in JSON format.
   -l, --function-url=<value>   URL of the function to run.
   -o, --connected-org=<value>  Username or alias for the target org; overrides default target org.
   -p, --payload=<value>        Set the payload of the cloudevent as a JSON object or a path to a file via @file.json.

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -20,7 +20,7 @@
   {
     "command": "env:delete",
     "plugin": "@salesforce/plugin-functions",
-    "flags": ["confirm", "environment", "target-compute"],
+    "flags": ["confirm", "environment", "target-compute", "json"],
     "alias": []
   },
   {

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -50,7 +50,8 @@
   {
     "command": "env:logdrain:remove",
     "plugin": "@salesforce/plugin-functions",
-    "flags": ["drain-url", "environment", "target-compute", "url", "json"]
+    "flags": ["drain-url", "environment", "json", "target-compute", "url"],
+    "alias": []
   },
   {
     "command": "env:var:get",
@@ -113,7 +114,7 @@
   {
     "command": "run:function",
     "plugin": "@salesforce/plugin-functions",
-    "flags": ["connected-org", "function-url", "headers", "payload", "structured", "url"],
+    "flags": ["connected-org", "function-url", "headers", "json", "payload", "structured", "url"],
     "alias": []
   },
   {

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -50,8 +50,7 @@
   {
     "command": "env:logdrain:remove",
     "plugin": "@salesforce/plugin-functions",
-    "flags": ["drain-url", "environment", "target-compute", "url"],
-    "alias": []
+    "flags": ["drain-url", "environment", "target-compute", "url", "json"]
   },
   {
     "command": "env:var:get",

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -6,15 +6,15 @@
     "alias": []
   },
   {
-    "command": "env:create:compute",
-    "plugin": "@salesforce/plugin-functions",
-    "flags": ["alias", "connected-org"],
-    "alias": []
-  },
-  {
     "command": "env:compute:collaborator:add",
     "plugin": "@salesforce/plugin-functions",
     "flags": ["heroku-user"],
+    "alias": []
+  },
+  {
+    "command": "env:create:compute",
+    "plugin": "@salesforce/plugin-functions",
+    "flags": ["alias", "connected-org"],
     "alias": []
   },
   {
@@ -56,7 +56,8 @@
   {
     "command": "env:var:get",
     "plugin": "@salesforce/plugin-functions",
-    "flags": ["environment", "target-compute", "json"]
+    "flags": ["environment", "json", "target-compute"],
+    "alias": []
   },
   {
     "command": "env:var:list",
@@ -67,7 +68,7 @@
   {
     "command": "env:var:set",
     "plugin": "@salesforce/plugin-functions",
-    "flags": ["environment", "target-compute"],
+    "flags": ["environment", "json", "target-compute"],
     "alias": []
   },
   {

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -24,15 +24,15 @@
     "alias": []
   },
   {
-    "command": "env:log:tail",
+    "command": "env:log",
     "plugin": "@salesforce/plugin-functions",
-    "flags": ["environment", "target-compute"],
+    "flags": ["environment", "num", "target-compute"],
     "alias": []
   },
   {
-    "command": "env:log",
+    "command": "env:log:tail",
     "plugin": "@salesforce/plugin-functions",
-    "flags": ["environment", "target-compute", "num"],
+    "flags": ["environment", "target-compute"],
     "alias": []
   },
   {
@@ -74,7 +74,7 @@
   {
     "command": "env:var:unset",
     "plugin": "@salesforce/plugin-functions",
-    "flags": ["environment", "target-compute"],
+    "flags": ["environment", "json", "target-compute"],
     "alias": []
   },
   {

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -38,7 +38,7 @@
   {
     "command": "env:logdrain:add",
     "plugin": "@salesforce/plugin-functions",
-    "flags": ["drain-url", "environment", "target-compute", "url"],
+    "flags": ["drain-url", "environment", "json", "target-compute", "url"],
     "alias": []
   },
   {

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -14,13 +14,13 @@
   {
     "command": "env:create:compute",
     "plugin": "@salesforce/plugin-functions",
-    "flags": ["alias", "connected-org"],
+    "flags": ["alias", "connected-org", "json"],
     "alias": []
   },
   {
     "command": "env:delete",
     "plugin": "@salesforce/plugin-functions",
-    "flags": ["confirm", "environment", "target-compute", "json"],
+    "flags": ["confirm", "environment", "json", "target-compute"],
     "alias": []
   },
   {

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -108,7 +108,7 @@
   {
     "command": "logout:functions",
     "plugin": "@salesforce/plugin-functions",
-    "flags": [],
+    "flags": ["json"],
     "alias": []
   },
   {

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -2,7 +2,7 @@
   {
     "command": "deploy:functions",
     "plugin": "@salesforce/plugin-functions",
-    "flags": ["branch", "connected-org", "force", "quiet"],
+    "flags": ["branch", "connected-org", "force", "json", "quiet"],
     "alias": []
   },
   {

--- a/src/commands/deploy/functions.ts
+++ b/src/commands/deploy/functions.ts
@@ -32,6 +32,12 @@ const messages = Messages.loadMessages('@salesforce/plugin-functions', 'project.
 export default class DeployFunctions extends Command {
   private git?: Git;
 
+  static summary = messages.getMessage('summary');
+
+  static description = messages.getMessage('description');
+
+  static examples = messages.getMessages('examples');
+
   static flags = {
     'connected-org': FunctionsFlagBuilder.connectedOrg({
       required: true,

--- a/src/commands/deploy/functions.ts
+++ b/src/commands/deploy/functions.ts
@@ -47,6 +47,7 @@ export default class DeployFunctions extends Command {
       description: messages.getMessage('flags.quiet.summary'),
       char: 'q',
     }),
+    json: FunctionsFlagBuilder.json,
   };
 
   async run() {
@@ -60,8 +61,11 @@ export default class DeployFunctions extends Command {
     // We don't want to deploy anything if they've got work that hasn't been committed yet because
     // it could end up being really confusing since the user isn't calling git directly
     if (await this.git.hasUnpushedFiles()) {
-      this.error(
-        'Your repo has files that have not been committed yet. Please either commit or stash them before deploying your project.'
+      this.handleError(
+        new Error(
+          'Your repo has files that have not been committed yet. Please either commit or stash them before deploying your project.'
+        ),
+        flags.json
       );
     }
 
@@ -81,8 +85,11 @@ export default class DeployFunctions extends Command {
     } catch (err) {
       const error = err as { body: { message?: string } };
       if (error.body.message?.includes("Couldn't find that app")) {
-        this.error(
-          `No compute environment found for org ${flags['connected-org']}. Please ensure you've created a compute environment before deploying.`
+        this.handleError(
+          new Error(
+            `No compute environment found for org ${flags['connected-org']}. Please ensure you've created a compute environment before deploying.`
+          ),
+          flags.json
         );
       }
 
@@ -90,7 +97,7 @@ export default class DeployFunctions extends Command {
     }
 
     if (flags.force && app.sales_org_connection?.sales_org_stage === 'prod') {
-      this.error('You cannot use the `--force` flag with a production org.');
+      this.handleError(new Error('You cannot use the `--force` flag with a production org.'), flags.json);
     }
 
     const remote = await this.git.getRemote(app, redactedToken, this.username);
@@ -114,12 +121,12 @@ export default class DeployFunctions extends Command {
       // if they've passed `--quiet` we don't want to show any build server output *unless* there's
       // an error, in which case we want to show all of it
       if (flags.quiet) {
-        this.error(error.message.replace(redactedToken, '<REDACTED>'));
+        this.handleError(new Error(error.message.replace(redactedToken, '<REDACTED>')), flags.json);
       }
 
       // In this case, they have not passed `--quiet`, in which case we have already streamed
       // the entirety of the build server output and don't need to show it again
-      this.error('There was an issue when deploying your functions.');
+      this.handleError(new Error('There was an issue when deploying your functions.'), flags.json);
     }
 
     debug('pushing function references', references);
@@ -141,7 +148,7 @@ export default class DeployFunctions extends Command {
         cli.error(`Unable to deploy FunctionReference for ${result.fullName}.`, { exit: false });
       }
 
-      if (!flags.quiet) {
+      if (!flags.quiet && !flags.json) {
         this.log(
           `Reference for ${result.fullName} ${
             result.created ? herokuColor.cyan('created') : herokuColor.green('updated')
@@ -181,6 +188,15 @@ export default class DeployFunctions extends Command {
 
     if (shouldExitNonZero) {
       cli.exit(1);
+    }
+    if (flags.json) {
+      cli.styledJSON({
+        status: 0,
+        result: {
+          results,
+        },
+        warnings: [],
+      });
     }
   }
 }

--- a/src/commands/env/create/compute.ts
+++ b/src/commands/env/create/compute.ts
@@ -86,13 +86,13 @@ export default class EnvCreateCompute extends Command {
           Id,
           Status,
           Error
-          FROM SfFunctionsConnection`);
+          FROM FunctionsConnection`);
       } catch (err) {
         const error = err as Error;
-        // This is obviously heinous, but should only exist short-term until the move from `SfFunctionsConnection`
+        // This is obviously heinous, but should only exist short-term until the move from `FunctionsConnection`
         // to `FunctionConnection` is complete. Once that's done, we can remove this and go back to a simple
         // query against `FunctionConnection`
-        if (!error.message.includes("sObject type 'SfFunctionsConnection' is not supported.")) {
+        if (!error.message.includes("sObject type 'FunctionsConnection' is not supported.")) {
           this.error(error);
         }
         response = await connection.query<FunctionConnectionRecord>(`SELECT

--- a/src/commands/env/delete.ts
+++ b/src/commands/env/delete.ts
@@ -45,6 +45,8 @@ export default class EnvDelete extends Command {
 
   async run() {
     const { flags } = await this.parse(EnvDelete);
+    this.postParseHook(flags);
+
     // We support both versions of the flag here for the sake of backward compat
     const targetCompute = flags['target-compute'] ?? flags.environment;
 
@@ -81,7 +83,7 @@ export default class EnvDelete extends Command {
         // If the error is the one we throw above, then we will send the error to the user.
         // If not (meaning the environment name provided might be a compute environment) then we swallow the error and proceed.
         if (error.message.includes(`The environment ${herokuColor.cyan(targetCompute)} is a Salesforce org.`)) {
-          this.handleError(error, flags.json);
+          this.error(error);
         }
       }
     }
@@ -101,11 +103,10 @@ export default class EnvDelete extends Command {
       app = response.data;
     } catch (error) {
       // App with name does not exist
-      this.handleError(
+      this.error(
         new Error(
           'Value provided for environment does not match a compute environment name or an alias to a compute environment.'
-        ),
-        flags.json
+        )
       );
     }
 
@@ -119,7 +120,7 @@ export default class EnvDelete extends Command {
       // of cleaning up functon refs since they're all already gone. Otherwise, something else has
       // gone wrong and we go ahead and bail out.
       if (error.message !== 'Attempted to resolve an org without a valid org ID') {
-        this.handleError(error, flags.json);
+        this.error(error);
       }
     }
 

--- a/src/commands/env/logdrain/add.ts
+++ b/src/commands/env/logdrain/add.ts
@@ -48,6 +48,8 @@ export default class LogDrainAdd extends Command {
 
   async run() {
     const { flags } = await this.parse(LogDrainAdd);
+    this.postParseHook(flags);
+
     // We support both versions of the flag here for the sake of backward compat
     const targetCompute = flags['target-compute'] ?? flags.environment;
     const url = flags['drain-url'] ?? flags.url;
@@ -108,24 +110,26 @@ export default class LogDrainAdd extends Command {
       const error = e as { data: { message?: string } };
 
       if (error.data?.message?.includes('Url is invalid')) {
-        this.handleError(new Error(`URL is invalid <${url}>`), flags.json);
+        this.error(new Error(`URL is invalid <${url}>`));
       }
 
       if (error.data?.message?.includes('Url has already been taken')) {
-        this.handleError(new Error(`Logdrain URL is already added <${url}>`), flags.json);
+        this.error(new Error(`Logdrain URL is already added <${url}>`));
       }
 
       if (error.data?.message?.includes("Couldn't find that app.")) {
-        this.handleError(new Error(`Could not find environment <${appName}>`), flags.json);
+        this.error(new Error(`Could not find environment <${appName}>`));
       }
 
       if (error.data?.message?.includes("You've reached the limit")) {
-        this.handleError(new Error(`You've reached the limit of 5 log drains on <${appName}>`), flags.json);
+        this.error(new Error(`You've reached the limit of 5 log drains on <${appName}>`));
       }
 
       if (error.data?.message?.includes('401')) {
-        this.handleError(new Error('Your token has expired, please login with sf login functions'), flags.json);
+        this.error(new Error('Your token has expired, please login with sf login functions'));
       }
+
+      this.error(e as Error);
     }
   }
 }

--- a/src/commands/env/logdrain/add.ts
+++ b/src/commands/env/logdrain/add.ts
@@ -43,6 +43,7 @@ export default class LogDrainAdd extends Command {
       description: messages.getMessage('flags.drain-url.summary'),
       hidden: true,
     }),
+    json: FunctionsFlagBuilder.json,
   };
 
   async run() {
@@ -74,17 +75,57 @@ export default class LogDrainAdd extends Command {
     if (flags.url) {
       cli.warn(messages.getMessage('flags.url.deprecation'));
     }
-
     const appName = await resolveAppNameForEnvironment(targetCompute);
 
-    cli.action.start(`Creating drain for environment ${herokuColor.app(targetCompute)}`);
+    try {
+      const result = await this.client.post<Heroku.LogDrain>(`/apps/${appName}/log-drains`, {
+        data: {
+          url,
+        },
+      });
 
-    await this.client.post<Heroku.LogDrain>(`/apps/${appName}/log-drains`, {
-      data: {
-        url,
-      },
-    });
+      if (flags.json) {
+        cli.styledJSON({
+          status: 0,
+          result: [
+            {
+              addon: null,
+              created_at: result.data.created_at,
+              id: result.data.id,
+              token: result.data.token,
+              updated_at: result.data.updated_at,
+              url: result.data.url,
+            },
+          ],
+          warnings: [],
+        });
+      } else {
+        cli.action.start(`Creating drain for environment ${herokuColor.app(targetCompute)}`);
 
-    cli.action.stop();
+        cli.action.stop();
+      }
+    } catch (e) {
+      const error = e as { data: { message?: string } };
+
+      if (error.data?.message?.includes('Url is invalid')) {
+        this.handleError(new Error(`URL is invalid <${url}>`), flags.json);
+      }
+
+      if (error.data?.message?.includes('Url has already been taken')) {
+        this.handleError(new Error(`Logdrain URL is already added <${url}>`), flags.json);
+      }
+
+      if (error.data?.message?.includes("Couldn't find that app.")) {
+        this.handleError(new Error(`Could not find environment <${appName}>`), flags.json);
+      }
+
+      if (error.data?.message?.includes("You've reached the limit")) {
+        this.handleError(new Error(`You've reached the limit of 5 log drains on <${appName}>`), flags.json);
+      }
+
+      if (error.data?.message?.includes('401')) {
+        this.handleError(new Error('Your token has expired, please login with sf login functions'), flags.json);
+      }
+    }
   }
 }

--- a/src/commands/env/logdrain/list.ts
+++ b/src/commands/env/logdrain/list.ts
@@ -35,6 +35,8 @@ export default class LogDrainList extends Command {
 
   async run() {
     const { flags } = await this.parse(LogDrainList);
+    this.postParseHook(flags);
+
     // We support both versions of the flag here for the sake of backward compat
     const targetCompute = flags['target-compute'] ?? flags.environment;
 

--- a/src/commands/env/logdrain/remove.ts
+++ b/src/commands/env/logdrain/remove.ts
@@ -48,6 +48,8 @@ export default class LogDrainRemove extends Command {
 
   async run() {
     const { flags } = await this.parse(LogDrainRemove);
+    this.postParseHook(flags);
+
     // We support both versions of the flag here for the sake of backward compat
     const targetCompute = flags['target-compute'] ?? flags.environment;
     const url = flags['drain-url'] ?? flags.url;
@@ -61,7 +63,7 @@ export default class LogDrainRemove extends Command {
     }
 
     if (!url) {
-      this.handleError(new Error('Missing required flag: -u, --url Logdrain url to remove'), flags.json);
+      this.error(new Error('Missing required flag: -u, --url Logdrain url to remove'));
     }
 
     if (flags.environment) {
@@ -87,17 +89,18 @@ export default class LogDrainRemove extends Command {
 
         cli.action.stop();
       }
-    } catch (e: any) {
+    } catch (e) {
       const error = e as { data: { message?: string } };
 
       if (error.data?.message?.includes('Url is invalid')) {
-        this.handleError(new Error(`URL is invalid <${url}>`), flags.json);
+        this.error(new Error(`URL is invalid <${url}>`));
       }
 
       if (error.data?.message?.includes("Couldn't find that app.")) {
-        this.handleError(new Error(`Couldn't find that app  <${appName}>`), flags.json);
+        this.error(new Error(`Couldn't find that app  <${appName}>`));
       }
-      return;
+
+      this.error(e as Error);
     }
   }
 }

--- a/src/commands/env/var/get.ts
+++ b/src/commands/env/var/get.ts
@@ -45,6 +45,7 @@ export default class VarGet extends Command {
 
   async run() {
     const { flags, args } = await this.parse(VarGet);
+    this.postParseHook(flags);
 
     // We support both versions of the flag here for the sake of backward compat
     const targetCompute = flags['target-compute'] ?? flags.environment;

--- a/src/commands/env/var/list.ts
+++ b/src/commands/env/var/list.ts
@@ -38,6 +38,8 @@ export default class ConfigList extends Command {
 
   async run() {
     const { flags } = await this.parse(ConfigList);
+    this.postParseHook(flags);
+
     // We support both versions of the flag here for the sake of backward compat
     const targetCompute = flags['target-compute'] ?? flags.environment;
 

--- a/src/commands/env/var/set.ts
+++ b/src/commands/env/var/set.ts
@@ -65,17 +65,9 @@ export default class ConfigSet extends Command {
     if (isInvalidEnvironment) {
       const errorStackStartIndex = errObj.indexOf('at');
       const errStack = errObj.substr(errorStackStartIndex);
-
-      cli.styledJSON({
-        status: 1,
-        name: 'Error',
-        message: `Couldn't find that app <${targetCompute}>`,
-        exitCode: 1,
-        commandName: 'env var set',
-        stack: errStack,
-        warnings: [],
-      });
-      return;
+      errorObject.message = `Couldn't find that app <${targetCompute}>`;
+      errorObject.stack = errStack;
+      this.error(errObj);
     }
 
     if (isInvalidInput) {
@@ -96,37 +88,24 @@ export default class ConfigSet extends Command {
         .replace(/\u001b\[.*?m\r?\n|\r/g, '')
         .replace('    ', '');
 
-      cli.styledJSON({
-        status: 1,
-        name: 'Error',
-        message: errMessage,
-        exitCode: 1,
-        commandName: 'env var set',
-        stack: errStack,
-        warnings: [],
-      });
-      return;
+      errorObject.message = errMessage;
+      errorObject.stack = errStack;
+      this.error(errObj);
     }
 
     if (hasNoInput) {
       const errorStackStartIndex = errObj.indexOf('at');
       const errStack = errObj.substr(errorStackStartIndex);
-
-      cli.styledJSON({
-        status: 1,
-        name: 'Error',
-        message: 'Must specify KEY and VALUE to set.',
-        exitCode: 1,
-        commandName: 'env var set',
-        stack: errStack,
-        warnings: [],
-      });
-      return;
+      errorObject.message = 'Must specify KEY and VALUE to set.';
+      errorObject.stack = errStack;
+      this.error(errObj);
     }
   }
 
   async run() {
     const { flags, argv } = await this.parse(ConfigSet);
+    this.postParseHook(flags);
+
     // We support both versions of the flag here for the sake of backward compat
     const targetCompute = flags['target-compute'] ?? flags.environment;
 

--- a/src/commands/env/var/unset.ts
+++ b/src/commands/env/var/unset.ts
@@ -40,6 +40,7 @@ export default class ConfigUnset extends Command {
 
   async run() {
     const { flags, argv } = await this.parse(ConfigUnset);
+    this.postParseHook(flags);
 
     // We support both versions of the flag here for the sake of backward compat
     const targetCompute = flags['target-compute'] ?? flags.environment;
@@ -73,17 +74,15 @@ export default class ConfigUnset extends Command {
       const error = e as Error;
 
       if (error.message?.includes('not correct config var')) {
-        this.handleError(
-          new Error(`Value provided for key does not match a config var found for <${appName}>.`),
-          flags.json
-        );
+        this.error(new Error(`Value provided for key does not match a config var found for <${appName}>.`));
       }
       if (error.message?.includes('404')) {
-        this.handleError(new Error(`Couldn't find that app <${appName}>`), flags.json);
+        this.error(new Error(`Couldn't find that app <${appName}>`));
       }
       if (error.message?.includes('401')) {
-        this.handleError(new Error('Your token has expired, please login with sf login functions'), flags.json);
+        this.error(new Error('Your token has expired, please login with sf login functions'));
       }
+      this.error(error);
     }
 
     const configPairs = argv.reduce((acc: any, elem: any) => {

--- a/src/commands/generate/function.ts
+++ b/src/commands/generate/function.ts
@@ -60,16 +60,11 @@ export default class GenerateFunction extends Command {
       cli.warn(messages.getMessage('flags.name.deprecation'));
     }
 
-    try {
-      const { name, path, language, welcomeText } = await generateFunction(fnName, flags.language as Language);
-      this.log(`Created ${language} function ${herokuColor.green(name)} in ${herokuColor.green(path)}.`);
-      if (welcomeText) {
-        this.log('');
-        this.log(welcomeText);
-      }
-    } catch (err) {
-      const error = err as Error;
-      this.error(error.message);
+    const { name, path, language, welcomeText } = await generateFunction(fnName, flags.language as Language);
+    this.log(`Created ${language} function ${herokuColor.green(name)} in ${herokuColor.green(path)}.`);
+    if (welcomeText) {
+      this.log('');
+      this.log(welcomeText);
     }
   }
 }

--- a/src/commands/login/functions/jwt.ts
+++ b/src/commands/login/functions/jwt.ts
@@ -14,6 +14,7 @@ import { cli } from 'cli-ux';
 import Command from '../../../lib/base';
 import { herokuVariant } from '../../../lib/heroku-variant';
 import { fetchSfdxProject } from '../../../lib/utils';
+import { FunctionsFlagBuilder } from '../../../lib/flags';
 
 // This is a public Oauth client created expressly for the purpose of headless auth in the functions CLI.
 // It does not require a client secret, is marked as public in the database and scoped accordingly
@@ -71,9 +72,7 @@ export default class JwtLogin extends Command {
       exclusive: ['instance-url'],
       hidden: true,
     }),
-    json: Flags.boolean({
-      description: messages.getMessage('flags.json.summary'),
-    }),
+    json: FunctionsFlagBuilder.json,
     alias: Flags.string({
       char: 'a',
       description: messages.getMessage('flags.alias.summary'),
@@ -117,9 +116,9 @@ export default class JwtLogin extends Command {
         username,
         oauth2Options,
       });
-    } catch (error) {
-      const err = error as SfdxError;
-      if (err.name === 'AuthInfoOverwriteError') {
+    } catch (err) {
+      const error = err as Error;
+      if (error.name === 'AuthInfoOverwriteError') {
         const remover = await AuthRemover.create();
         await remover.removeAuth(username);
         authInfo = await AuthInfo.create({
@@ -127,7 +126,7 @@ export default class JwtLogin extends Command {
           oauth2Options,
         });
       } else {
-        throw err;
+        this.error(error);
       }
     }
     await authInfo.save();
@@ -136,6 +135,8 @@ export default class JwtLogin extends Command {
 
   async run() {
     const { flags } = await this.parse(JwtLogin);
+    this.postParseHook(flags);
+
     const { clientid, username, keyfile } = flags;
     // We support both versions of the flag here for the sake of backward compat
     const instanceUrl = flags['instance-url'] ?? flags.instanceurl;
@@ -148,24 +149,7 @@ export default class JwtLogin extends Command {
 
     // Use keyfile, clientid, and username to auth with salesforce via the same workflow
     // as sfdx auth:jwt:grant --json
-    let auth;
-
-    try {
-      auth = await this.initAuthInfo(username, clientid, keyfile, instanceUrl);
-    } catch (error) {
-      const err = error as SfdxError;
-      if (flags.json) {
-        cli.styledJSON({
-          status: 1,
-          exitCode: err.exitCode,
-          name: err.name,
-          message: err.message,
-          warnings: [],
-        });
-        cli.exit(1);
-      }
-      throw err;
-    }
+    const auth = await this.initAuthInfo(username, clientid, keyfile, instanceUrl);
 
     // Take care of any alias/default setting that needs to happen for the sfdx credential
     // before we move on to the heroku stuff

--- a/src/commands/logout/functions.ts
+++ b/src/commands/logout/functions.ts
@@ -24,6 +24,8 @@ export default class Login extends Command {
 
   async run() {
     const { flags } = await this.parse(Login);
+    this.postParseHook(flags);
+
     cli.action.start(messages.getMessage('action.start'));
 
     this.stateAggregator.tokens.unset(Command.TOKEN_BEARER_KEY);

--- a/src/commands/logout/functions.ts
+++ b/src/commands/logout/functions.ts
@@ -8,6 +8,7 @@ import { cli } from 'cli-ux';
 import { Messages } from '@salesforce/core';
 
 import Command from '../../lib/base';
+import { FunctionsFlagBuilder } from '../../lib/flags';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-functions', 'logout.functions');
@@ -17,12 +18,24 @@ export default class Login extends Command {
 
   static examples = messages.getMessages('examples');
 
+  static flags = {
+    json: FunctionsFlagBuilder.json,
+  };
+
   async run() {
+    const { flags } = await this.parse(Login);
     cli.action.start(messages.getMessage('action.start'));
 
     this.stateAggregator.tokens.unset(Command.TOKEN_BEARER_KEY);
     await this.stateAggregator.tokens.write();
 
     cli.action.stop();
+    if (flags.json) {
+      cli.styledJSON({
+        status: 0,
+        result: [],
+        warnings: [],
+      });
+    }
   }
 }

--- a/src/commands/run/function.ts
+++ b/src/commands/run/function.ts
@@ -57,6 +57,8 @@ export default class Invoke extends Command {
 
   async run() {
     const { flags } = await this.parse(Invoke);
+    this.postParseHook(flags);
+
     const url = flags['function-url'] ?? flags.url;
     if (!url) {
       throw new Errors.CLIError(
@@ -103,10 +105,9 @@ export default class Invoke extends Command {
     } catch (e) {
       const error = e as AxiosError;
       if (error.response) {
-        this.handleError(new Error(`${error.response.status} ${error.response.statusText}`), flags.json);
-      } else {
-        this.handleError(new Error(`${error.message}`), flags.json);
+        this.error(new Error(`${error.response.status} ${error.response.statusText}`));
       }
+      this.error(new Error(`${error.message}`));
     }
   }
 

--- a/src/commands/run/function.ts
+++ b/src/commands/run/function.ts
@@ -5,13 +5,15 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import * as fs from 'fs';
-import { Command, Errors, Flags } from '@oclif/core';
+import { Errors, Flags } from '@oclif/core';
 import { runFunction, RunFunctionOptions } from '@hk/functions-core';
 import { cli } from 'cli-ux';
 import herokuColor from '@heroku-cli/color';
 import { AxiosResponse, AxiosError } from 'axios';
 import { ConfigAggregator, Messages } from '@salesforce/core';
 import getStdin from '../../lib/get-stdin';
+import { FunctionsFlagBuilder } from '../../lib/flags';
+import Command from '../../lib/base';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-functions', 'run.function');
@@ -50,6 +52,7 @@ export default class Invoke extends Command {
       char: 'o',
       description: messages.getMessage('flags.connected-org.summary'),
     }),
+    json: FunctionsFlagBuilder.json,
   };
 
   async run() {
@@ -62,7 +65,7 @@ export default class Invoke extends Command {
        See more help with --help`
       );
     }
-    if (flags.url) {
+    if (flags.url && !flags.json) {
       cli.warn(messages.getMessage('flags.url.deprecation'));
     }
     flags.payload = await this.getPayloadData(flags.payload);
@@ -75,27 +78,34 @@ export default class Invoke extends Command {
       cli.warn('No -o connected org or target-org found, context will be partially initialized');
     }
     const aliasOrUser = flags['connected-org'] || `target-org ${targetOrg}`;
-    this.log(`Using ${aliasOrUser} login credential to initialize context`);
+    if (!flags.json) {
+      cli.log(`Using ${aliasOrUser} login credential to initialize context`);
+      cli.action.start(`${herokuColor.cyanBright('POST')} ${url}`);
+    }
     const runFunctionOptions = {
       ...flags,
       url,
       targetusername: flags['connected-org'] ?? targetOrg,
     };
-    cli.action.start(`${herokuColor.cyanBright('POST')} ${url}`);
+
     try {
       const response = await runFunction(runFunctionOptions as RunFunctionOptions);
-      cli.action.stop(herokuColor.greenBright(response.status.toString()));
-      this.writeResponse(response);
-    } catch (err) {
-      const error = err as AxiosError;
-      cli.debug(error as unknown as string);
-      if (error.response) {
-        cli.action.stop(herokuColor.redBright(`${error.response.status} ${error.response.statusText}`));
-        this.debug(error.response);
-        this.error(error.response.data as string);
+      if (flags.json) {
+        cli.styledJSON({
+          status: 0,
+          result: response.data,
+          warnings: [],
+        });
       } else {
-        cli.action.stop(herokuColor.redBright('Error'));
-        this.error(error);
+        this.writeResponse(response);
+        cli.action.stop(herokuColor.greenBright(response.status.toString()));
+      }
+    } catch (e) {
+      const error = e as AxiosError;
+      if (error.response) {
+        this.handleError(new Error(`${error.response.status} ${error.response.statusText}`), flags.json);
+      } else {
+        this.handleError(new Error(`${error.message}`), flags.json);
       }
     }
   }
@@ -106,7 +116,6 @@ export default class Invoke extends Command {
     }
     return payload || getStdin();
   }
-
   writeResponse(response: AxiosResponse) {
     const contentType = response.headers['content-type'];
     if (contentType.includes('application/json') || contentType.includes('application/cloudevents+json')) {

--- a/src/commands/run/function/start/container.ts
+++ b/src/commands/run/function/start/container.ts
@@ -93,12 +93,8 @@ export default class Container extends Command {
       env: flags.env,
     };
 
-    let descriptor;
-    try {
-      descriptor = await getProjectDescriptor(buildOpts.descriptor);
-    } catch (error) {
-      cli.error(error as Error);
-    }
+    const descriptor = await getProjectDescriptor(buildOpts.descriptor);
+
     const functionName = descriptor.com.salesforce.id as string;
 
     const benny = await getFunctionsBinary();

--- a/src/commands/whoami/functions.ts
+++ b/src/commands/whoami/functions.ts
@@ -36,6 +36,8 @@ export default class WhoAmI extends Command {
 
   async run(): Promise<FunctionsInformation> {
     const { flags } = await this.parse(WhoAmI);
+    this.postParseHook(flags);
+
     const ret: FunctionsInformation = {};
     const account = await this.fetchAccount();
 

--- a/src/lib/base.ts
+++ b/src/lib/base.ts
@@ -151,4 +151,19 @@ export default abstract class Command extends SfCommand<any> {
       }
     }
   }
+
+  protected handleError(error: Error, json?: boolean): never {
+    if (json) {
+      const { name, message } = error;
+      cli.styledJSON({
+        status: 1,
+        message,
+        name,
+        warnings: [],
+      });
+      cli.exit(1);
+    } else {
+      this.error(error);
+    }
+  }
 }

--- a/src/lib/base.ts
+++ b/src/lib/base.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { URL } from 'url';
+import { Interfaces } from '@oclif/core';
 import { SfCommand } from '@salesforce/sf-plugins-core';
 import { StateAggregator, Org } from '@salesforce/core';
 import { cli } from 'cli-ux';
@@ -23,6 +24,8 @@ export default abstract class Command extends SfCommand<any> {
   private _client?: APIClient;
 
   private _auth?: string;
+
+  protected outputJSON = false;
 
   protected async init(): Promise<void> {
     await super.init();
@@ -152,9 +155,16 @@ export default abstract class Command extends SfCommand<any> {
     }
   }
 
-  protected handleError(error: Error, json?: boolean): never {
-    if (json) {
-      const { name, message } = error;
+  // This interface is copied from oclif/core
+  error(input: string | Error, options: { code?: string; exit: false } & Interfaces.PrettyPrintableError): void;
+  error(input: string | Error, options?: { code?: string; exit?: number } & Interfaces.PrettyPrintableError): never;
+  error(
+    input: string | Error,
+    options: { code?: string; exit?: number | false } & Interfaces.PrettyPrintableError = {}
+  ): void {
+    if (this.outputJSON) {
+      if (typeof input === 'string') input = new Error(input);
+      const { message, name } = input;
       cli.styledJSON({
         status: 1,
         message,
@@ -163,7 +173,11 @@ export default abstract class Command extends SfCommand<any> {
       });
       cli.exit(1);
     } else {
-      this.error(error);
+      super.error(input, options as any);
     }
+  }
+
+  protected postParseHook(flags: { [name: string]: string | boolean | number | string[] | undefined }) {
+    this.outputJSON = flags.json as boolean;
   }
 }

--- a/src/lib/project-toml.ts
+++ b/src/lib/project-toml.ts
@@ -5,7 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { ProjectDescriptor } from '@heroku/project-descriptor';
-import { cli } from 'cli-ux';
 
 export async function parseProjectToml(fnTomlPath: string): Promise<any> {
   const parser = new ProjectDescriptor();
@@ -14,9 +13,9 @@ export async function parseProjectToml(fnTomlPath: string): Promise<any> {
   } catch (err) {
     const error = err as Error;
     if (error.message.includes('File Not Found')) {
-      cli.error(error.message + ' Are you in the correct working directory?');
+      throw new Error(error.message + ' Are you in the correct working directory?');
     } else {
-      cli.error(error.message);
+      throw new Error(error.message);
     }
   }
 }

--- a/test/commands/env/create/compute.test.ts
+++ b/test/commands/env/create/compute.test.ts
@@ -255,8 +255,8 @@ describe('sf env create compute', () => {
     .add('queryStub', () => {
       const queryStub = sinon.stub();
       queryStub
-        .withArgs(sinon.match('SfFunctionsConnection'))
-        .throws({ message: "sObject type 'SfFunctionsConnection' is not supported." });
+        .withArgs(sinon.match('FunctionsConnection'))
+        .throws({ message: "sObject type 'FunctionsConnection' is not supported." });
 
       queryStub.withArgs(sinon.match('FunctionConnection')).returns({
         records: [
@@ -293,7 +293,7 @@ describe('sf env create compute', () => {
         .reply(200, APP_MOCK);
     })
     .command(['env:create:compute', '-o', `${ORG_ALIAS}`, '-a', `${ENVIRONMENT_ALIAS}`])
-    .it('still creates a compute env even if SfFunctionsConnection is not supported', (ctx) => {
+    .it('still creates a compute env even if FunctionsConnection is not supported', (ctx) => {
       expect(ctx.stderr).to.contain(`Creating compute environment for org ID ${ORG_MOCK.id}`);
       expect(ctx.stdout).to.contain(`New compute environment created with ID ${APP_MOCK.name}`);
       expect(ctx.stdout).to.contain(`Your compute environment with local alias ${ENVIRONMENT_ALIAS} is ready`);

--- a/test/commands/env/create/compute.test.ts
+++ b/test/commands/env/create/compute.test.ts
@@ -148,9 +148,9 @@ describe('sf env create compute', () => {
     .retries(3)
     .do(() => {
       orgStub = sandbox.stub(Org, 'create' as any).returns(ORG_MOCK);
-      sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
+      sandbox.stub(SfProject, 'resolve' as any).returns(PROJECT_MOCK);
       sandbox.stub(AliasAccessor.prototype, 'set' as any).callsFake(aliasSetSpy);
-      AuthStubs.write.callsFake(aliasWriteSpy);
+      AuthStubs.aliasesWrite.callsFake(aliasWriteSpy);
     })
     .finally(() => {
       sandbox.restore();
@@ -220,7 +220,7 @@ describe('sf env create compute', () => {
     .stderr()
     .do(() => {
       orgStub = sandbox.stub(Org, 'create' as any).returns(ORG_MOCK);
-      sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
+      sandbox.stub(SfProject, 'resolve' as any).returns(PROJECT_MOCK);
     })
     .finally(() => {
       sandbox.restore();

--- a/test/commands/env/delete.test.ts
+++ b/test/commands/env/delete.test.ts
@@ -65,7 +65,7 @@ describe('env:delete', () => {
     .nock('https://api.heroku.com', (api) => api.get(`/apps/${COMPUTE_ENV_NAME}`).reply(200))
     .do(() => {
       sandbox.stub(Utils, 'resolveOrg' as any).returns(ORG_MOCK);
-      sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
+      sandbox.stub(SfProject, 'resolve' as any).returns(PROJECT_MOCK);
       sandbox.stub(Utils, 'findOrgExpirationStatus' as any).returns(false);
     })
     .finally(() => {

--- a/test/commands/env/delete.test.ts
+++ b/test/commands/env/delete.test.ts
@@ -60,6 +60,27 @@ describe('env:delete', () => {
 
   test
     .stderr()
+    .stdout()
+    .nock('https://api.heroku.com', (api) => api.delete(`/apps/${COMPUTE_ENV_NAME}`).reply(200))
+    .nock('https://api.heroku.com', (api) => api.get(`/apps/${COMPUTE_ENV_NAME}`).reply(200))
+    .do(() => {
+      sandbox.stub(Utils, 'resolveOrg' as any).returns(ORG_MOCK);
+      sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
+      sandbox.stub(Utils, 'findOrgExpirationStatus' as any).returns(false);
+    })
+    .finally(() => {
+      sandbox.restore();
+    })
+    .command(['env:delete', `--target-compute=${COMPUTE_ENV_NAME}`, `--confirm=${COMPUTE_ENV_NAME}`, '--json'])
+    .it('deletes an environment and returns json', (ctx) => {
+      expect(ctx.stderr).to.include(`Deleting environment ${COMPUTE_ENV_NAME}... done`);
+      expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
+        vacuum('{\n"status": 0,\n"result": "Environment deleted.",\n"warnings": []\n}')
+      );
+    });
+
+  test
+    .stderr()
     .do(() => {
       sandbox.stub(Utils, 'resolveOrg' as any).returns(ORG_MOCK);
       sandbox.stub(SfProject, 'resolve' as any).returns(PROJECT_MOCK);
@@ -82,9 +103,9 @@ describe('env:delete', () => {
     .nock('https://api.heroku.com', (api) => api.delete(`/apps/${COMPUTE_ENV_NAME}`).reply(200))
     .nock('https://api.heroku.com', (api) => api.get(`/apps/${COMPUTE_ENV_NAME}`).reply(200))
     .do(() => {
-      sandbox.stub(Utils, 'resolveOrg' as any).throws('Attempted to resolve an org without a valid org ID');
+      sandbox.stub(Utils, 'findOrgExpirationStatus' as any).throws('This function should not have been called');
     })
-    .add('projectResolveStub', () => {
+    .add('findOrgStub', () => {
       return sandbox.stub(SfProject, 'resolve' as any).returns(PROJECT_MOCK);
     })
     .finally(() => {
@@ -96,7 +117,7 @@ describe('env:delete', () => {
       expect(output).to.include(`Deleting environment ${COMPUTE_ENV_NAME}... done`);
       // If they're deleting the environment after deleting the org, the command shouldn't attempt
       // to clean up function references, and therefore it shouldn't attempt to resolve the project
-      expect(ctx.projectResolveStub).to.not.have.been.called;
+      expect(ctx.findOrgStub).to.not.have.been.called;
     });
 
   test

--- a/test/commands/env/logdrain/add.test.ts
+++ b/test/commands/env/logdrain/add.test.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { CLIError } from '@oclif/core/lib/errors';
 import { expect, test } from '@oclif/test';
 import vacuum from '../../../helpers/vacuum';
 
@@ -12,6 +13,18 @@ const APP_NAME = 'my-app';
 const LOG_DRAIN = {
   id: '1',
   url: 'https://logs-r-us.com/1',
+};
+
+const LOG_DRAIN_ENV_ERR = {
+  message: "Couldn't find that app.",
+};
+
+const LOG_DRAIN_INVALID_URL = {
+  message: 'Url is invalid.',
+};
+
+const LOG_DRAIN_ALREADY_USED = {
+  message: 'Url has already been taken',
 };
 
 describe('sf env logdrain add', () => {
@@ -46,6 +59,64 @@ describe('sf env logdrain add', () => {
     .it('will use url if passed using the old flag (not --drain-url)', (ctx) => {
       expect(vacuum(ctx.stderr).replace(/\n[›»]/gm, '')).to.contain(
         vacuum('--url is deprecated and will be removed in a future release. Please use --drain-url going forward.')
+      );
+    });
+
+  test
+    .stdout()
+    .nock('https://api.heroku.com', (api) => api.post(`/apps/${APP_NAME}/log-drains`).reply(200, LOG_DRAIN))
+    .command(['env:logdrain:add', '--target-compute', APP_NAME, '-u', LOG_DRAIN.url, '--json'])
+    .retries(3)
+    .it('will show json output', (ctx) => {
+      expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
+        vacuum(
+          '{\n"status": 0,\n"result": [\n{\n"addon": null,\n"id": "1",\n"url": "https://logs-r-us.com/1"\n}\n],\n"warnings": []\n}'
+        )
+      );
+    });
+
+  test
+    .stdout()
+    .nock('https://api.heroku.com', (api) =>
+      api.post('/apps/invalid-environment/log-drains').reply(404, LOG_DRAIN_ENV_ERR)
+    )
+    .command(['env:logdrain:add', '--target-compute', 'invalid-environment', '-u', LOG_DRAIN.url, '--json'])
+    .catch((error) => {
+      expect((error as CLIError).oclif.exit).to.equal(1);
+    })
+    .it('will show json output error with incorrect compute environment', (ctx) => {
+      expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
+        vacuum('{\n"status": 1,\n"message": "Could not find environment <invalid-environment>"')
+      );
+    });
+
+  test
+    .stdout()
+    .nock('https://api.heroku.com', (api) => api.post(`/apps/${APP_NAME}/log-drains`).reply(422, LOG_DRAIN_INVALID_URL))
+    .command(['env:logdrain:add', '--target-compute', APP_NAME, '-u', 'invalid-url', '--json'])
+    .catch((error) => {
+      expect((error as CLIError).oclif.exit).to.equal(1);
+    })
+    .it('will show json output error with incorrect drain-url', (ctx) => {
+      expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
+        vacuum('{\n"status": 1,\n"message": "URL is invalid <invalid-url>",\n"name": "Error"')
+      );
+    });
+
+  test
+    .stdout()
+    .nock('https://api.heroku.com', (api) =>
+      api.post(`/apps/${APP_NAME}/log-drains`).reply(422, LOG_DRAIN_ALREADY_USED)
+    )
+    .command(['env:logdrain:add', '--target-compute', APP_NAME, '-u', LOG_DRAIN.url, '--json'])
+    .catch((error) => {
+      expect((error as CLIError).oclif.exit).to.equal(1);
+    })
+    .it('will show json output error with drain-url already used', (ctx) => {
+      expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
+        vacuum(
+          '{\n"status": 1,\n"message": "Logdrain URL is already added <https://logs-r-us.com/1>",\n"name": "Error",'
+        )
       );
     });
 });

--- a/test/commands/env/var/unset.test.ts
+++ b/test/commands/env/var/unset.test.ts
@@ -4,10 +4,23 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { CLIError } from '@oclif/core/lib/errors';
 import { expect, test } from '@oclif/test';
 import vacuum from '../../../helpers/vacuum';
 
 describe('sf env:var:unset', () => {
+  const jsonSuccess = {
+    status: 0,
+    result: null,
+    warnings: [],
+  };
+  const jsonAppError = {
+    status: 1,
+    name: 'Error',
+    message: "Couldn't find that app <my-environment>",
+    warnings: [],
+  };
+
   test
     .stdout()
     .stderr()
@@ -17,6 +30,11 @@ describe('sf env:var:unset', () => {
           foo: null,
         })
         .reply(200)
+        .get('/apps/my-environment/config-vars')
+        .reply(200, {
+          foo: 'bar',
+          baz: 'baq',
+        })
     )
     .command(['env:var:unset', 'foo', '--target-compute', 'my-environment'])
     .it('works with a single variable', (ctx) => {
@@ -30,9 +48,51 @@ describe('sf env:var:unset', () => {
       api
         .patch('/apps/my-environment/config-vars', {
           foo: null,
+        })
+        .reply(200)
+        .get('/apps/my-environment/config-vars')
+        .reply(200, {
+          foo: 'bar',
+          baz: 'baq',
+        })
+    )
+    .command(['env:var:unset', 'foo', '--target-compute', 'my-environment', '--json'])
+    .it('will show json output with success', (ctx) => {
+      const succJSON = JSON.parse(ctx.stdout);
+
+      expect(succJSON.status).to.deep.equal(jsonSuccess.status);
+      expect(succJSON.result).to.eql(jsonSuccess.result);
+    });
+
+  test
+    .stdout()
+    .stderr()
+    .command(['env:var:unset', 'foo', '--target-compute', 'my-environment', '--json'])
+    .catch((error) => {
+      expect((error as CLIError).oclif.exit).to.equal(1);
+    })
+    .it('will show json output with app error', (ctx) => {
+      const errJSON = JSON.parse(ctx.stdout);
+
+      expect(errJSON.status).to.eql(jsonAppError.status);
+      expect(errJSON.message).to.eql(jsonAppError.message);
+    });
+
+  test
+    .stdout()
+    .stderr()
+    .nock('https://api.heroku.com', (api) =>
+      api
+        .patch('/apps/my-environment/config-vars', {
+          foo: null,
           bar: null,
         })
         .reply(200)
+        .get('/apps/my-environment/config-vars')
+        .reply(200, {
+          foo: 'bar',
+          baz: 'baq',
+        })
     )
     .command(['env:var:unset', 'foo', 'bar', '--target-compute', 'my-environment'])
     .it('works with a multiple variables', (ctx) => {
@@ -47,6 +107,11 @@ describe('sf env:var:unset', () => {
           foo: null,
         })
         .reply(200)
+        .get('/apps/my-environment/config-vars')
+        .reply(200, {
+          foo: 'bar',
+          baz: 'baq',
+        })
     )
     .command(['env:var:unset', 'foo', '--environment', 'my-environment'])
     .it('will use a compute environment if passed using the old flag (not --target-compute)', (ctx) => {
@@ -61,7 +126,15 @@ describe('sf env:var:unset', () => {
     .stderr()
     .command(['env:var:unset', '--target-compute', 'my-environment'])
     .catch((error) => {
-      expect(error.message).to.contain('you must enter a config var key (i.e. mykey)');
+      expect(error.message).to.contain('You must enter a config var key (i.e. mykey).');
     })
     .it('errors when no argument is given');
+
+  test
+    .stdout()
+    .command(['env:var:unset', 'foo', '--environment', 'my-environment2'])
+    .catch((error) => {
+      expect(error.message).to.contain("Couldn't find that app <my-environment2>");
+    })
+    .it('errors with incorrect compute environment');
 });

--- a/test/commands/login/functions/jwt.test.ts
+++ b/test/commands/login/functions/jwt.test.ts
@@ -322,7 +322,6 @@ describe('sf login functions jwt', () => {
     .stderr()
     .do(() => {
       sinon.stub(AuthInfo, 'create' as any).throws({
-        exitCode: 1,
         name: 'JwtAuthError',
         message: 'oops no auth',
       });
@@ -344,7 +343,6 @@ describe('sf login functions jwt', () => {
     .it('returns the correct json payload when --json is used and sfdx auth errors', (ctx) => {
       expect(JSON.parse(ctx.stdout)).to.deep.equal({
         status: 1,
-        exitCode: 1,
         name: 'JwtAuthError',
         message: 'oops no auth',
         warnings: [],

--- a/test/commands/logout/functions.test.ts
+++ b/test/commands/logout/functions.test.ts
@@ -4,11 +4,12 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { test } from '@oclif/test';
+import { expect, test } from '@oclif/test';
 import type { SfTokens } from '@salesforce/core';
 import { TokenAccessor } from '@salesforce/core/lib/stateAggregator';
 import * as sinon from 'sinon';
 import { AuthStubs } from '../../helpers/auth';
+import vacuum from '../../helpers/vacuum';
 
 describe('sf logout functions', () => {
   let contents: SfTokens;
@@ -26,5 +27,14 @@ describe('sf logout functions', () => {
     .command(['logout:functions'])
     .it('removes the functions key from the tokens field on logout', (ctx) => {
       sinon.assert.match(contents, {});
+    });
+  test
+    .stdout()
+    .stderr()
+    .command(['logout:functions', '-j'])
+    .it('will show json output', (ctx) => {
+      expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
+        vacuum('{\n"status": 0,\n"result": [],\n"warnings": []\n}')
+      );
     });
 });

--- a/test/commands/project/deploy/functions.test.ts
+++ b/test/commands/project/deploy/functions.test.ts
@@ -86,6 +86,25 @@ const ORG_MOCK_WITH_DELETED_FUNCTION = {
   ...ORG_MOCK,
 };
 
+const jsonSuccess = {
+  status: 0,
+  result: {
+    results: [
+      {
+        created: true,
+        fullName: 'sweet_project-fn1',
+        success: true,
+      },
+      {
+        created: true,
+        fullName: 'sweet_project-fn2',
+        success: true,
+      },
+    ],
+  },
+  warnings: [],
+};
+
 ORG_MOCK_WITH_DELETED_FUNCTION.getConnection = function () {
   return {
     metadata: {
@@ -149,6 +168,33 @@ describe('sf project deploy functions', () => {
       expect(ctx.stdout).to.include('Reference for sweet_project-fn1 created');
       expect(ctx.stdout).to.include('Reference for sweet_project-fn2 created');
       expect(ctx.stdout).to.not.include('Removing the following functions that were deleted locally:');
+    });
+
+  test
+    .stdout()
+    .stderr()
+    .do(() => {
+      sandbox.stub(Git.prototype as any, 'hasUnpushedFiles').returns(false);
+      sandbox.stub(Git.prototype, 'status' as any).returns('On branch main');
+      const gitExecStub = sandbox.stub(Git.prototype, 'exec' as any);
+      gitExecStub.withArgs(sinon.match.array.startsWith(['push'])).returns({ stdout: '', stderr: '' });
+
+      sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
+      sandbox.stub(Org, 'create' as any).returns(ORG_MOCK);
+
+      sandbox.stub(FunctionReferenceUtils, 'resolveFunctionReferences' as any).returns(FUNCTION_REFS_MOCK);
+    })
+    .finally(() => {
+      sandbox.restore();
+    })
+    .nock('https://api.heroku.com', (api) => {
+      api.get(`/sales-org-connections/${ORG_MOCK.id}/apps/${PROJECT_CONFIG_MOCK.name}`).reply(200, ENVIRONMENT_MOCK);
+    })
+    .command(['deploy:functions', '--connected-org=my-scratch-org', '--json'])
+    .it('will show json output with success', (ctx) => {
+      const succJSON = JSON.parse(ctx.stdout);
+      expect(succJSON.status).to.deep.equal(jsonSuccess.status);
+      expect(succJSON.result).to.eql(jsonSuccess.result);
     });
 
   // When specifying another branch

--- a/test/commands/run/function.test.ts
+++ b/test/commands/run/function.test.ts
@@ -22,6 +22,7 @@ describe('run:function', () => {
   let sandbox: sinon.SinonSandbox;
   let runFunctionStub: sinon.SinonStub;
   let stopActionSub: sinon.SinonStub;
+
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     runFunctionStub = sandbox.stub(library, 'runFunction');
@@ -53,7 +54,15 @@ describe('run:function', () => {
       config.set(OrgConfigProperties.TARGET_ORG, testData.username);
       await config.write();
     });
-
+    test
+      .stdout()
+      .stderr()
+      .command(['run:function', '-l', targetUrl, '-p', userpayload, '-j'])
+      .it('will show json output', (ctx) => {
+        expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
+          vacuum('{\n"status": 0,\n"result": "Something happened!",\n"warnings": []\n}')
+        );
+      });
     test
       .stdout()
       .stderr()
@@ -78,6 +87,7 @@ describe('run:function', () => {
         '--structured',
         '-o',
         OrgConfigProperties.TARGET_ORG,
+        '-j',
       ])
       .it('Should call the library with all arguments', async () => {
         sinon.assert.calledWith(
@@ -88,8 +98,10 @@ describe('run:function', () => {
             .and(sinon.match.has('headers', ['TestHeader']))
             .and(sinon.match.has('structured', true))
             .and(sinon.match.has('targetusername', OrgConfigProperties.TARGET_ORG))
+            .and(sinon.match.has('json', true))
         );
       });
+
     test
       .stdout()
       .stderr()
@@ -116,6 +128,7 @@ describe('run:function', () => {
       .it('Should log response', async (ctx) => {
         expect(ctx.stdout).to.contain('Something happened!');
       });
+
     test
       .command(['run:function', '-l', targetUrl, '-p', userpayload])
       .it('Should stop spinner and display status code', async () => {
@@ -139,9 +152,9 @@ describe('run:function', () => {
       .stderr()
       .stub(process, 'exit', () => '')
       .command(['run:function', '-l', targetUrl, '-p', userpayload])
-      .catch((error) => expect(error.message).to.contain('Something bad happened!'))
+      .catch((error) => expect(error.message).to.contain('500 undefined'))
       .finally(() => {
-        sinon.assert.calledWith(stopActionSub, sinon.match('500'));
+        sinon.assert.calledWith(stopActionSub, sinon.match('failed'));
       })
       .it('Should log response and stop spinner with status code');
   });
@@ -159,7 +172,7 @@ describe('run:function', () => {
       .command(['run:function', '-l', targetUrl, '-p', userpayload])
       .catch((error) => expect(error.message).to.contain(errorMessage))
       .finally(() => {
-        sinon.assert.calledWith(stopActionSub, sinon.match('Error'));
+        sinon.assert.calledWith(stopActionSub, sinon.match('failed'));
       })
       .it('Should log error and stop spinner with status code');
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -844,6 +844,41 @@
     widest-line "^3.1.0"
     wrap-ansi "^7.0.0"
 
+"@oclif/core@^1.5.1", "@oclif/core@^1.5.2", "@oclif/core@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.6.0.tgz#a91333275cd43a49097158f4ae8e15ccf718bd48"
+  integrity sha512-JHerjgRd29EtUVpDIrzohq2XdxJfgmZVGHAFlf75QVhLGFaleopZAQNBXkHkxG//kGib0LhyVGW7azcFKzr1eQ==
+  dependencies:
+    "@oclif/linewrap" "^1.0.0"
+    "@oclif/screen" "^3.0.2"
+    ansi-escapes "^4.3.2"
+    ansi-styles "^4.3.0"
+    cardinal "^2.1.1"
+    chalk "^4.1.2"
+    clean-stack "^3.0.1"
+    cli-progress "^3.10.0"
+    debug "^4.3.3"
+    ejs "^3.1.6"
+    fs-extra "^9.1.0"
+    get-package-type "^0.1.0"
+    globby "^11.1.0"
+    hyperlinker "^1.0.0"
+    indent-string "^4.0.0"
+    is-wsl "^2.2.0"
+    js-yaml "^3.14.1"
+    lodash "^4.17.21"
+    natural-orderby "^2.0.3"
+    object-treeify "^1.1.33"
+    password-prompt "^1.1.2"
+    semver "^7.3.5"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+    supports-color "^8.1.1"
+    supports-hyperlinks "^2.2.0"
+    tslib "^2.3.1"
+    widest-line "^3.1.0"
+    wrap-ansi "^7.0.0"
+
 "@oclif/dev-cli@^1":
   version "1.26.0"
   resolved "https://registry.yarnpkg.com/@oclif/dev-cli/-/dev-cli-1.26.0.tgz#e3ec294b362c010ffc8948003d3770955c7951fd"
@@ -7964,6 +7999,11 @@ prettier@^2.0.5, prettier@^2.6.0:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+
+prettier@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.0.tgz#12f8f504c4d8ddb76475f441337542fa799207d4"
+  integrity sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==
 
 pretty-bytes@^5.2.0, pretty-bytes@^5.3.0:
   version "5.6.0"


### PR DESCRIPTION
### What does this PR do?

Adds --json output to all commands that hadn't yet implemented it. This PR also makes all commands inherit from SfCommand to increase parity of SF CLI commands.

### What issues does this PR fix or reference?

@W-10019547@

Misc to-do:
- [x] inherit SfCommand class
- [x] add --json output on missing commands
- [x] update readme
