### PR TITLE
fix: commands indicate the wrong argument flag in error msg

### DIFF
--- a/src/commands/env/delete.ts
+++ b/src/commands/env/delete.ts
@@ -50,7 +50,7 @@ export default class EnvDelete extends Command {
     if (!targetCompute) {
       throw new Errors.CLIError(
         `Missing required flag:
-        -c, --target-compute TARGET-COMPUTE  ${herokuColor.dim('Environment name.')}
+        -e, --target-compute TARGET-COMPUTE  ${herokuColor.dim('Environment name.')}
        See more help with --help`
       );
     }

--- a/src/commands/env/log/tail.ts
+++ b/src/commands/env/log/tail.ts
@@ -42,7 +42,7 @@ export default class LogTail extends Command {
     if (!targetCompute) {
       throw new Errors.CLIError(
         `Missing required flag:
-        -c, --target-compute TARGET-COMPUTE  ${herokuColor.dim('Environment name.')}
+        -e, --target-compute TARGET-COMPUTE  ${herokuColor.dim('Environment name.')}
        See more help with --help`
       );
     }

--- a/src/commands/env/logdrain/add.ts
+++ b/src/commands/env/logdrain/add.ts
@@ -54,7 +54,7 @@ export default class LogDrainAdd extends Command {
     if (!targetCompute) {
       throw new Errors.CLIError(
         `Missing required flag:
-        -c, --target-compute TARGET-COMPUTE  ${herokuColor.dim('Environment name.')}
+        -e, --target-compute TARGET-COMPUTE  ${herokuColor.dim('Environment name.')}
        See more help with --help`
       );
     }

--- a/src/commands/env/logdrain/list.ts
+++ b/src/commands/env/logdrain/list.ts
@@ -41,7 +41,7 @@ export default class LogDrainList extends Command {
     if (!targetCompute) {
       throw new Errors.CLIError(
         `Missing required flag:
-        -c, --target-compute TARGET-COMPUTE  ${herokuColor.dim('Environment name.')}
+        -e, --target-compute TARGET-COMPUTE  ${herokuColor.dim('Environment name.')}
        See more help with --help`
       );
     }

--- a/src/commands/env/logdrain/remove.ts
+++ b/src/commands/env/logdrain/remove.ts
@@ -54,7 +54,7 @@ export default class LogDrainRemove extends Command {
     if (!targetCompute) {
       throw new Errors.CLIError(
         `Missing required flag:
-        -c, --target-compute TARGET-COMPUTE  ${herokuColor.dim('Environment name.')}
+        -e, --target-compute TARGET-COMPUTE  ${herokuColor.dim('Environment name.')}
        See more help with --help`
       );
     }

--- a/src/commands/env/var/get.ts
+++ b/src/commands/env/var/get.ts
@@ -52,7 +52,7 @@ export default class VarGet extends Command {
     if (!targetCompute) {
       throw new Errors.CLIError(
         `Missing required flag:
-        -c, --target-compute TARGET-COMPUTE  ${herokuColor.dim('Environment name.')}
+        -e, --target-compute TARGET-COMPUTE  ${herokuColor.dim('Environment name.')}
        See more help with --help`
       );
     }

--- a/src/commands/env/var/list.ts
+++ b/src/commands/env/var/list.ts
@@ -44,7 +44,7 @@ export default class ConfigList extends Command {
     if (!targetCompute) {
       throw new Errors.CLIError(
         `Missing required flag:
-        -c, --target-compute TARGET-COMPUTE  ${herokuColor.dim('Environment name.')}
+        -e, --target-compute TARGET-COMPUTE  ${herokuColor.dim('Environment name.')}
        See more help with --help`
       );
     }

--- a/src/commands/env/var/set.ts
+++ b/src/commands/env/var/set.ts
@@ -60,7 +60,7 @@ export default class ConfigSet extends Command {
     if (!targetCompute) {
       throw new Errors.CLIError(
         `Missing required flag:
-        -c, --target-compute TARGET-COMPUTE  ${herokuColor.dim('Environment name.')}
+        -e, --target-compute TARGET-COMPUTE  ${herokuColor.dim('Environment name.')}
        See more help with --help`
       );
     }

--- a/src/commands/env/var/unset.ts
+++ b/src/commands/env/var/unset.ts
@@ -43,7 +43,7 @@ export default class ConfigUnset extends Command {
     if (!targetCompute) {
       throw new Errors.CLIError(
         `Missing required flag:
-        -c, --target-compute TARGET-COMPUTE  ${herokuColor.dim('Environment name.')}
+        -e, --target-compute TARGET-COMPUTE  ${herokuColor.dim('Environment name.')}
        See more help with --help`
       );
     }


### PR DESCRIPTION
### What issues does this PR fix or reference?
[@W-10989984@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000usBW5YAM/view) [sf-cli] bug: commands indicate the wrong argument flag

### What does this PR do?

Update help text for --target-compute. 
Has:
`-c, --target-compute`
Should be:
`-e, --target-compute`
Fix for:

- [x] `sf env var list`
- [x] `sf env var set`
- [x] `sf env var unset`
- [x] `sf env var get`
- [x] `sf env delete`
- [x] `sf env log tail`
- [x] `sf env logdrain add`
- [x] `sf env logdrain list`
- [x] `sf env logdrain remove`


Example output:

```

╭─scope@scope-ltmcxql ~/projects/plugin-functions ‹zw/add-json-sf-env-var-set●›

╰─$ ./bin/run env var set                                   141 ↵

 ›  Error: Missing required flag:

 ›      -c, --target-compute TARGET-COMPUTE Environment name.

 ›     See more help with --help

```



Does not match the help output:

```

╭─scope@scope-ltmcxql ~/projects/plugin-functions ‹zw/add-json-sf-env-var-set●›

╰─$ sf env var set --help                                   141 ↵

Set a single config value for an environment.

USAGE

 $ sf env var set [-e <value> | ]

FLAGS

 -e, --target-compute=<value> Environment name.

EXAMPLES

 Set a config value:

  $ sf env var set [KEY]=[VALUE] --target-compute environment-alias

```

Will close this related Issue: https://github.com/forcedotcom/cli/issues/1550