### PR TITLE
chore: rm test-ts-update CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,17 +102,6 @@ workflows:
           filters:
             branches:
               only: main
-  test-ts-update:
-    triggers:
-      - schedule:
-          cron: 0 0 * * *
-          filters:
-            branches:
-              only:
-                - main
-    jobs:
-      - release-management/test-ts-update:
-          es_target: ES2021
   just-nuts:
     when: << pipeline.parameters.run-just-nuts >>
     jobs:


### PR DESCRIPTION
### What does this PR do?
Removes the test-ts-update CI job. 

We can address typescript changes when we update the dependency.

### What issues does this PR fix or reference?
