### PR TITLE
docs: lower case the example function name in help message for `generate function`

### DIFF
--- a/messages/generate.function.md
+++ b/messages/generate.function.md
@@ -10,7 +10,7 @@ Both '--language' and '--name' are required flags. Function names must start wit
 
 - Create a JavaScript function:
 
-  <%= config.bin %> <%= command.id %> --function-name MyFunction --language javascript
+  <%= config.bin %> <%= command.id %> --function-name myfunction --language javascript
 
 # flags.function-name.summary
 


### PR DESCRIPTION
### What does this PR do?

Makes the example function name `myfunction` rather than `MyFunction`.

Before:
`sf generate function --function-name MyFunction --language javascript`

After:
 `sf generate function --function-name myfunction --language javascript`

### How to test
```
./bin/dev generate function --help
```

### What issues does this PR fix or reference?
 @W-000@