### PR TITLE
ci: fix dependabot-automerge job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,4 +127,5 @@ workflows:
                 - main
     jobs:
       - release-management/dependabot-automerge:
+          merge-method: squash
           context: release


### PR DESCRIPTION
### What does this PR do?
fix dependabot-automerge job to use squash not merge which is blocked on this repo

### What issues does this PR fix or reference?

W-X