### PR TITLE
chore(release): 1.10.0 [ci skip]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-functions",
   "description": "Functions plugin for the SF CLI",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "author": "heroku-front-end@salesforce.com",
   "bin": {
     "functions": "./bin/run"


### PR DESCRIPTION
### What does this PR do?
v1.10.0 is missing in the commit history

### What issues does this PR fix or reference?
@W-0@