### PR TITLE
fix: generalize the description of the "env create" topic

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
         "description": "Commands to manage your environments, such as orgs and compute environments.",
         "subtopics": {
           "create": {
-            "description": "Commands to create a compute environment for use with Salesforce Functions."
+            "description": "Commands to create environments."
           },
           "log": {
             "description": "Commands to stream log output for an environment."


### PR DESCRIPTION
### What does this PR do?

The core plugin-env plugin also contains an "env create" subtopic, so we need to make the descriptions of the two the same.  I'm changing the description in this plugin to be more general.

### What issues does this PR fix or reference?
@W-11241703@