### PR TITLE
feat: use StateAggregator

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@heroku/project-descriptor": "0.0.6",
     "@hk/functions-core": "npm:@heroku/functions-core@0.2.8",
     "@oclif/core": "^1.6.0",
-    "@salesforce/core": "^3.8.0",
+    "@salesforce/core": "^3.19.4",
     "@salesforce/plugin-org": "^1.11.2",
     "@salesforce/sf-plugins-core": "^1.7.2",
     "@salesforce/ts-sinon": "^1.3.21",

--- a/src/commands/env/create/compute.ts
+++ b/src/commands/env/create/compute.ts
@@ -144,9 +144,8 @@ export default class EnvCreateCompute extends Command {
       cli.action.start('Connecting environments');
 
       if (alias) {
-        this.globalInfo.aliases.set(alias, app.id!);
-
-        await this.globalInfo.write();
+        this.stateAggregator.aliases.set(alias, app.id!);
+        await this.stateAggregator.aliases.write();
       }
 
       cli.action.stop();

--- a/src/commands/login/functions.ts
+++ b/src/commands/login/functions.ts
@@ -62,23 +62,23 @@ export default class Login extends Command {
 
     const refreshToken = data.refresh_token;
 
-    this.globalInfo.tokens.set(Command.TOKEN_BEARER_KEY, { token: bearerToken, url: this.identityUrl.toString() });
+    this.stateAggregator.tokens.set(Command.TOKEN_BEARER_KEY, { token: bearerToken, url: this.identityUrl.toString() });
 
-    await this.globalInfo.write();
+    await this.stateAggregator.tokens.write();
 
     const account = await this.fetchAccount();
 
-    this.globalInfo.tokens.update(Command.TOKEN_BEARER_KEY, { user: account.salesforce_username });
+    this.stateAggregator.tokens.update(Command.TOKEN_BEARER_KEY, { user: account.salesforce_username });
 
     if (refreshToken) {
-      this.globalInfo.tokens.set(Command.TOKEN_REFRESH_KEY, {
+      this.stateAggregator.tokens.set(Command.TOKEN_REFRESH_KEY, {
         token: refreshToken,
         url: this.identityUrl.toString(),
         user: account.salesforce_username,
       });
     }
 
-    await this.globalInfo.write();
+    await this.stateAggregator.tokens.write();
 
     cli.action.stop();
   }

--- a/src/commands/login/functions/jwt.ts
+++ b/src/commands/login/functions/jwt.ts
@@ -218,13 +218,13 @@ export default class JwtLogin extends Command {
     // the new heroku credentials we're about to generate
     this.resetClientAuth();
 
-    this.globalInfo.tokens.set(Command.TOKEN_BEARER_KEY, {
+    this.stateAggregator.tokens.set(Command.TOKEN_BEARER_KEY, {
       token: bearerToken,
       url: this.identityUrl.toString(),
       user: auth.getUsername(),
     });
 
-    await this.globalInfo.write();
+    await this.stateAggregator.tokens.write();
 
     if (flags.json) {
       cli.styledJSON({

--- a/src/commands/logout/functions.ts
+++ b/src/commands/logout/functions.ts
@@ -20,8 +20,8 @@ export default class Login extends Command {
   async run() {
     cli.action.start(messages.getMessage('action.start'));
 
-    this.globalInfo.tokens.unset(Command.TOKEN_BEARER_KEY);
-    await this.globalInfo.write();
+    this.stateAggregator.tokens.unset(Command.TOKEN_BEARER_KEY);
+    await this.stateAggregator.tokens.write();
 
     cli.action.stop();
   }

--- a/src/hooks/envDisplay.ts
+++ b/src/hooks/envDisplay.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { GlobalInfo } from '@salesforce/core';
+import { StateAggregator } from '@salesforce/core';
 import { SfHook } from '@salesforce/sf-plugins-core';
 import APIClient, { herokuClientApiUrl } from '../lib/api-client';
 import { ensureArray } from '../lib/function-reference-utils';
@@ -34,14 +34,14 @@ interface ComputeEnv {
 }
 
 const hook: SfHook.EnvDisplay<ComputeEnv> = async function (opts) {
-  const info = await GlobalInfo.getInstance();
+  const stateAggregator = await StateAggregator.getInstance();
   const apiKey = process.env.SALESFORCE_FUNCTIONS_API_KEY;
   let auth;
 
   if (apiKey) {
     auth = apiKey;
   } else {
-    const token = info.tokens.get('functions-bearer', true)?.token;
+    const token = stateAggregator.tokens.get('functions-bearer', true)?.token;
 
     if (!token) {
       throw new Error('Not authenticated. Please login with `sf login functions`.');

--- a/src/hooks/envList.ts
+++ b/src/hooks/envList.ts
@@ -6,7 +6,7 @@
  */
 
 import { SfHook, EnvList } from '@salesforce/sf-plugins-core';
-import { AuthInfo, GlobalInfo, ConfigEntry, OrgAuthorization } from '@salesforce/core';
+import { AuthInfo, StateAggregator, ConfigEntry, OrgAuthorization } from '@salesforce/core';
 import herokuVariant from '../lib/heroku-variant';
 import { ComputeEnvironment, Dictionary, SfdcAccount } from '../lib/sfdc-types';
 import { fetchSfdxProject } from '../lib/utils';
@@ -32,14 +32,14 @@ async function fetchAccount(client: APIClient) {
 }
 
 async function resolveEnvironments(orgs: OrgAuthorization[]): Promise<ComputeEnvironment[]> {
-  const info = await GlobalInfo.getInstance();
+  const stateAggregator = await StateAggregator.getInstance();
   const apiKey = process.env.SALESFORCE_FUNCTIONS_API_KEY;
   let auth;
 
   if (apiKey) {
     auth = apiKey;
   } else {
-    const token = info.tokens.get('functions-bearer', true)?.token;
+    const token = stateAggregator.tokens.get('functions-bearer', true)?.token;
 
     if (!token) {
       throw new Error('Not authenticated. Please login with `sf login functions`.');
@@ -93,9 +93,9 @@ async function resolveAliasForValue(environmentName: string, entries: ConfigEntr
 }
 
 async function resolveAliasesForComputeEnvironments(envs: ComputeEnvironment[]) {
-  const info = await GlobalInfo.getInstance();
+  const stateAggregator = await StateAggregator.getInstance();
 
-  const entries = Object.entries(info.aliases.getAll());
+  const entries = Object.entries(stateAggregator.aliases.getAll()) as ConfigEntry[];
 
   return Promise.all(
     envs.map(async (env) => {

--- a/src/lib/base.ts
+++ b/src/lib/base.ts
@@ -6,7 +6,7 @@
  */
 import { URL } from 'url';
 import { SfCommand } from '@salesforce/sf-plugins-core';
-import { GlobalInfo, Org } from '@salesforce/core';
+import { StateAggregator, Org } from '@salesforce/core';
 import { cli } from 'cli-ux';
 import APIClient, { herokuClientApiUrl } from './api-client';
 import herokuVariant from './heroku-variant';
@@ -18,7 +18,7 @@ export default abstract class Command extends SfCommand<any> {
   // We want to implement `--json` on a per-command basis, so we disable the global json flag here
   static enableJsonFlag = false;
 
-  protected globalInfo!: GlobalInfo;
+  protected stateAggregator!: StateAggregator;
 
   private _client?: APIClient;
 
@@ -26,7 +26,7 @@ export default abstract class Command extends SfCommand<any> {
 
   protected async init(): Promise<void> {
     await super.init();
-    this.globalInfo = await GlobalInfo.getInstance();
+    this.stateAggregator = await StateAggregator.getInstance();
   }
 
   protected get identityUrl(): URL {
@@ -37,7 +37,7 @@ export default abstract class Command extends SfCommand<any> {
   }
 
   protected get username() {
-    return this.globalInfo.tokens.get(Command.TOKEN_BEARER_KEY)?.user;
+    return this.stateAggregator.tokens.get(Command.TOKEN_BEARER_KEY)?.user;
   }
 
   protected resetClientAuth() {
@@ -52,7 +52,7 @@ export default abstract class Command extends SfCommand<any> {
       if (apiKey) {
         this._auth = apiKey;
       } else {
-        const token = this.globalInfo.tokens.get(Command.TOKEN_BEARER_KEY, true)?.token;
+        const token = this.stateAggregator.tokens.get(Command.TOKEN_BEARER_KEY, true)?.token;
 
         if (!token) {
           throw new Error(`Not authenticated. Please login with \`${this.config.bin} login functions\`.`);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { AuthInfo, GlobalInfo, Org, OrgAuthorization, SfdxProject } from '@salesforce/core';
+import { AuthInfo, StateAggregator, Org, OrgAuthorization, SfdxProject } from '@salesforce/core';
 import APIClient from './api-client';
 import herokuVariant from './heroku-variant';
 import { ComputeEnvironment, SfdxProjectConfig } from './sfdc-types';
@@ -43,8 +43,8 @@ export async function fetchAppForProject(client: APIClient, projectName: string,
 
 export async function resolveAppNameForEnvironment(appNameOrAlias: string): Promise<string> {
   // Check if the environment provided is an alias or not, to determine what app name we use to attempt deletion
-  const info = await GlobalInfo.getInstance();
-  const matchingAlias = info.aliases.getValue(appNameOrAlias);
+  const stateAggregator = await StateAggregator.getInstance();
+  const matchingAlias = stateAggregator.aliases.getValue(appNameOrAlias);
   let appName: string;
   if (matchingAlias) {
     appName = matchingAlias;
@@ -74,8 +74,8 @@ export async function getOrgUsername(orgId: string): Promise<string | undefined>
 }
 
 export async function getOrgAlias(orgId: string): Promise<string | undefined> {
-  const info = await GlobalInfo.getInstance();
-  const entries = Object.entries(info.aliases.getAll());
+  const stateAggregator = await StateAggregator.getInstance();
+  const entries = Object.entries(stateAggregator.aliases.getAll());
   const username = await getOrgUsername(orgId);
   const matchingAlias = entries.find((entry) => entry[1] === username);
 

--- a/test/commands/env/create/compute.test.ts
+++ b/test/commands/env/create/compute.test.ts
@@ -5,8 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { expect, test } from '@oclif/test';
-import { Org, SfdxProject } from '@salesforce/core';
-import { AliasAccessor } from '@salesforce/core/lib/globalInfo';
+import { Org, SfProject } from '@salesforce/core';
+import { AliasAccessor } from '@salesforce/core/lib/stateAggregator';
 import * as sinon from 'sinon';
 import { AuthStubs } from '../../../helpers/auth';
 
@@ -71,7 +71,7 @@ describe('sf env create compute', () => {
     .retries(3)
     .do(() => {
       sandbox.stub(Org, 'create' as any).returns(ORG_MOCK);
-      sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
+      sandbox.stub(SfProject, 'resolve' as any).returns(PROJECT_MOCK);
     })
     .finally(() => {
       sandbox.restore();
@@ -94,6 +94,7 @@ describe('sf env create compute', () => {
 
   const aliasSetSpy = sandbox.spy();
   const aliasWriteSpy = sandbox.spy();
+  // const setAliasSpy = sandbox.spy();
 
   test
     .stdout()
@@ -101,9 +102,9 @@ describe('sf env create compute', () => {
     .retries(3)
     .do(() => {
       orgStub = sandbox.stub(Org, 'create' as any).returns(ORG_MOCK);
-      sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
+      sandbox.stub(SfProject, 'resolve' as any).returns(PROJECT_MOCK);
       sandbox.stub(AliasAccessor.prototype, 'set' as any).callsFake(aliasSetSpy);
-      AuthStubs.write.callsFake(aliasWriteSpy);
+      AuthStubs.aliasesWrite.callsFake(aliasWriteSpy);
     })
     .finally(() => {
       sandbox.restore();
@@ -130,7 +131,7 @@ describe('sf env create compute', () => {
     .stderr()
     .do(() => {
       orgStub = sandbox.stub(Org, 'create' as any).returns(ORG_MOCK);
-      sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK_NO_NAME);
+      sandbox.stub(SfProject, 'resolve' as any).returns(PROJECT_MOCK_NO_NAME);
     })
     .finally(() => {
       sandbox.restore();
@@ -146,7 +147,7 @@ describe('sf env create compute', () => {
     .stderr()
     .do(() => {
       orgStub = sandbox.stub(Org, 'create' as any).returns(ORG_MOCK);
-      sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
+      sandbox.stub(SfProject, 'resolve' as any).returns(PROJECT_MOCK);
     })
     .finally(() => {
       sandbox.restore();
@@ -173,9 +174,9 @@ describe('sf env create compute', () => {
     .stderr()
     .retries(3)
     .do(() => {
-      sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
+      sandbox.stub(SfProject, 'resolve' as any).returns(PROJECT_MOCK);
       sandbox.stub(AliasAccessor.prototype, 'set' as any).callsFake(aliasSetSpy);
-      AuthStubs.write.callsFake(aliasWriteSpy);
+      AuthStubs.aliasesWrite.callsFake(aliasWriteSpy);
     })
     .add('queryStub', () => {
       const queryStub = sinon.stub();
@@ -233,7 +234,7 @@ describe('sf env create compute', () => {
     .stderr()
     .do(() => {
       orgStub = sandbox.stub(Org, 'create' as any).returns(ORG_MOCK);
-      sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
+      sandbox.stub(SfProject, 'resolve' as any).returns(PROJECT_MOCK);
       CONN_MOCK.metadata.list = sinon.stub().throws('INVALID_TYPE');
     })
     .finally(() => {

--- a/test/commands/env/delete.test.ts
+++ b/test/commands/env/delete.test.ts
@@ -5,8 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { expect, test } from '@oclif/test';
-import { Org, SfdxProject } from '@salesforce/core';
-import { AliasAccessor } from '@salesforce/core/lib/globalInfo';
+import { Org, SfProject } from '@salesforce/core';
+import { AliasAccessor } from '@salesforce/core/lib/stateAggregator';
 import * as sinon from 'sinon';
 import * as Utils from '../../../src/lib/utils';
 import vacuum from '../../helpers/vacuum';
@@ -46,7 +46,7 @@ describe('env:delete', () => {
     .nock('https://api.heroku.com', (api) => api.get(`/apps/${COMPUTE_ENV_NAME}`).reply(200))
     .do(() => {
       sandbox.stub(Utils, 'resolveOrg' as any).returns(ORG_MOCK);
-      sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
+      sandbox.stub(SfProject, 'resolve' as any).returns(PROJECT_MOCK);
       sandbox.stub(Utils, 'findOrgExpirationStatus' as any).returns(false);
     })
     .finally(() => {
@@ -62,7 +62,7 @@ describe('env:delete', () => {
     .stderr()
     .do(() => {
       sandbox.stub(Utils, 'resolveOrg' as any).returns(ORG_MOCK);
-      sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
+      sandbox.stub(SfProject, 'resolve' as any).returns(PROJECT_MOCK);
       sandbox.stub(AliasAccessor.prototype, 'getValue').returns(COMPUTE_ENV_NAME);
       sandbox.stub(Utils, 'findOrgExpirationStatus' as any).returns(false);
     })
@@ -85,7 +85,7 @@ describe('env:delete', () => {
       sandbox.stub(Utils, 'resolveOrg' as any).throws('Attempted to resolve an org without a valid org ID');
     })
     .add('projectResolveStub', () => {
-      return sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
+      return sandbox.stub(SfProject, 'resolve' as any).returns(PROJECT_MOCK);
     })
     .finally(() => {
       sandbox.restore();
@@ -104,7 +104,7 @@ describe('env:delete', () => {
     .nock('https://api.heroku.com', (api) => api.get(`/apps/${COMPUTE_ENV_NAME}`).reply(404))
     .do(() => {
       sandbox.stub(Utils, 'resolveOrg' as any).returns({});
-      sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
+      sandbox.stub(SfProject, 'resolve' as any).returns(PROJECT_MOCK);
       sandbox.stub(Utils, 'fetchOrg' as any).returns(ORG_MOCK);
     })
     .finally(() => {
@@ -144,7 +144,7 @@ describe('env:delete', () => {
     .stderr()
     .do(() => {
       sandbox.stub(Utils, 'resolveOrg' as any).returns(ORG_MOCK);
-      sandbox.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
+      sandbox.stub(SfProject, 'resolve' as any).returns(PROJECT_MOCK);
       sandbox.stub(AliasAccessor.prototype, 'getValue').returns(COMPUTE_ENV_NAME);
       sandbox.stub(Utils, 'findOrgExpirationStatus' as any).returns(false);
     })

--- a/test/commands/login/functions.test.ts
+++ b/test/commands/login/functions.test.ts
@@ -5,7 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { expect, test } from '@oclif/test';
-import type { GlobalInfo, SfTokens } from '@salesforce/core';
+import type { SfTokens } from '@salesforce/core';
+import { TokenAccessor } from '@salesforce/core/lib/stateAggregator';
 import { cli } from 'cli-ux';
 import * as sinon from 'sinon';
 import { AuthStubs } from '../../helpers/auth';
@@ -16,9 +17,9 @@ describe('sf login functions', () => {
 
   beforeEach(() => {
     windowOpenStub = sinon.stub();
-    AuthStubs.write.callsFake(async function (this: GlobalInfo) {
-      contents = this.tokens.getAll(true);
-      return this.getContents();
+    AuthStubs.tokensWrite.callsFake(async function (this: TokenAccessor) {
+      contents = this.getAll(true);
+      return contents;
     });
   });
 

--- a/test/commands/login/functions/jwt.test.ts
+++ b/test/commands/login/functions/jwt.test.ts
@@ -6,7 +6,8 @@
  */
 import { CLIError } from '@oclif/core/lib/errors';
 import { expect, test } from '@oclif/test';
-import { AuthInfo, GlobalInfo, SfdxProject, SfTokens } from '@salesforce/core';
+import { AuthInfo, SfProject, SfTokens } from '@salesforce/core';
+import { TokenAccessor } from '@salesforce/core/lib/stateAggregator';
 import * as sinon from 'sinon';
 import { AuthStubs } from '../../../helpers/auth';
 import vacuum from '../../../helpers/vacuum';
@@ -42,9 +43,9 @@ describe('sf login functions jwt', () => {
   let contents: SfTokens;
 
   beforeEach(() => {
-    AuthStubs.write.callsFake(async function (this: GlobalInfo) {
-      contents = this.tokens.getAll(true);
-      return this.getContents();
+    AuthStubs.tokensWrite.callsFake(async function (this: TokenAccessor) {
+      contents = this.getAll(true);
+      return contents;
     });
   });
 
@@ -53,7 +54,7 @@ describe('sf login functions jwt', () => {
     .stderr()
     .do(() => {
       sinon.stub(AuthInfo, 'create' as any).returns(AUTH_INFO_STUB);
-      sinon.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
+      sinon.stub(SfProject, 'resolve' as any).returns(PROJECT_MOCK);
     })
     .finally(() => {
       sinon.restore();
@@ -176,7 +177,7 @@ describe('sf login functions jwt', () => {
     .stdout()
     .stderr()
     .do(() => {
-      sinon.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
+      sinon.stub(SfProject, 'resolve' as any).returns(PROJECT_MOCK);
     })
     .add('AuthInfoCreateStub', () => {
       return sinon.stub(AuthInfo, 'create' as any).returns(AUTH_INFO_STUB);
@@ -213,7 +214,7 @@ describe('sf login functions jwt', () => {
     .stdout()
     .stderr()
     .do(() => {
-      sinon.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
+      sinon.stub(SfProject, 'resolve' as any).returns(PROJECT_MOCK);
       sinon.stub(AuthInfo, 'create' as any).returns(AUTH_INFO_STUB);
     })
     .finally(() => {
@@ -271,7 +272,7 @@ describe('sf login functions jwt', () => {
           privateKey: PRIVATE_KEY_PATH,
         }),
       });
-      sinon.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
+      sinon.stub(SfProject, 'resolve' as any).returns(PROJECT_MOCK);
     })
     .finally(() => {
       sinon.restore();
@@ -325,7 +326,7 @@ describe('sf login functions jwt', () => {
         name: 'JwtAuthError',
         message: 'oops no auth',
       });
-      sinon.stub(SfdxProject, 'resolve' as any).returns(PROJECT_MOCK);
+      sinon.stub(SfProject, 'resolve' as any).returns(PROJECT_MOCK);
     })
     .finally(() => {
       sinon.restore();

--- a/test/commands/logout/functions.test.ts
+++ b/test/commands/logout/functions.test.ts
@@ -5,7 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { test } from '@oclif/test';
-import type { GlobalInfo, SfTokens } from '@salesforce/core';
+import type { SfTokens } from '@salesforce/core';
+import { TokenAccessor } from '@salesforce/core/lib/stateAggregator';
 import * as sinon from 'sinon';
 import { AuthStubs } from '../../helpers/auth';
 
@@ -13,9 +14,9 @@ describe('sf logout functions', () => {
   let contents: SfTokens;
 
   beforeEach(() => {
-    AuthStubs.write.callsFake(async function (this: GlobalInfo) {
-      contents = this.tokens.getAll(true);
-      return this.getContents();
+    AuthStubs.tokensWrite.callsFake(async function (this: TokenAccessor) {
+      contents = this.getAll(true);
+      return contents;
     });
   });
 

--- a/test/commands/run/function.test.ts
+++ b/test/commands/run/function.test.ts
@@ -48,10 +48,9 @@ describe('run:function', () => {
   context('with payload and other arguments', () => {
     beforeEach(async () => {
       testData = new MockTestOrgData();
-      $$.configStubs.GlobalInfo = { contents: { orgs: { [testData.username]: await testData.getConfig() } } };
-
+      await $$.stubAuths(testData);
       const config = await Config.create(Config.getDefaultOptions(true));
-      await config.set(OrgConfigProperties.TARGET_ORG, testData.username);
+      config.set(OrgConfigProperties.TARGET_ORG, testData.username);
       await config.write();
     });
 

--- a/test/helpers/auth.ts
+++ b/test/helpers/auth.ts
@@ -5,8 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { GlobalInfo } from '@salesforce/core';
-import { TokenAccessor } from '@salesforce/core/lib/globalInfo';
+import { AliasAccessor, TokenAccessor } from '@salesforce/core/lib/stateAggregator';
 import { stubMethod } from '@salesforce/ts-sinon';
 import { createSandbox, SinonStub } from 'sinon';
 import NetrcMachine from '../../src/lib/netrc';
@@ -15,7 +14,8 @@ const sandbox = createSandbox();
 
 export const AuthStubs: {
   getToken: SinonStub;
-  write: SinonStub;
+  tokensWrite: SinonStub;
+  aliasesWrite: SinonStub;
   netrc: SinonStub;
 } = {} as any; // set to any - will be initialized later
 
@@ -27,7 +27,8 @@ process.nextTick(() => {
       user: 'login',
     });
     // Ensure we don't do an actual write
-    AuthStubs.write = stubMethod(sandbox, GlobalInfo.prototype, 'write');
+    AuthStubs.tokensWrite = stubMethod(sandbox, TokenAccessor.prototype, 'write');
+    AuthStubs.aliasesWrite = stubMethod(sandbox, AliasAccessor.prototype, 'write');
 
     // Make sure this returns nothing, it should use it from global info
     AuthStubs.netrc = sandbox.stub(NetrcMachine.prototype, 'get' as any);


### PR DESCRIPTION
### What does this PR do?
Use `StateAggregator` instead of `GlobalInfo`

`GlobalInfo` is being deprecated because it is highly susceptible to data loss and/or collisions since it uses a single json file for all state across all processes. `StateAggregator` splits all individual bits of state into individual files so that there's a much smaller chance of data loss when multiple commands are running concurrently. 

For reference: https://github.com/forcedotcom/sfdx-core/pull/587

### What issues does this PR fix or reference?
@W-11214501@