### PR TITLE
fix: deploy functions help

### DIFF
--- a/src/commands/deploy/functions.ts
+++ b/src/commands/deploy/functions.ts
@@ -32,6 +32,12 @@ const messages = Messages.loadMessages('@salesforce/plugin-functions', 'project.
 export default class DeployFunctions extends Command {
   private git?: Git;
 
+  static summary = messages.getMessage('summary');
+
+  static description = messages.getMessage('description');
+
+  static examples = messages.getMessages('examples');
+
   static flags = {
     'connected-org': FunctionsFlagBuilder.connectedOrg({
       required: true,


### PR DESCRIPTION
### What does this PR do?

Fix to show description, summary, and examples with the --help flag on sf deploy functions.

BEFORE
<img width="1340" alt="Screen Shot 2022-06-29 at 10 34 38 AM" src="https://user-images.githubusercontent.com/2197515/176464881-02cda298-01f1-40bb-898e-ea910139058c.png">
---
AFTER
<img width="1334" alt="Screen Shot 2022-06-29 at 10 34 46 AM" src="https://user-images.githubusercontent.com/2197515/176464905-a33a4e0c-db25-4d59-8925-488a54c31dbb.png">

### What issues does this PR fix or reference?

[@@W-10004934@@](https://gus.lightning.force.com/lightning/r/a07EE00000EMZlbYAH/view)


