### PR TITLE
refactor: rename SfFunctionsConnection to FunctionConnection

### DIFF
--- a/src/commands/env/create/compute.ts
+++ b/src/commands/env/create/compute.ts
@@ -93,7 +93,7 @@ export default class EnvCreateCompute extends Command {
         // to `FunctionConnection` is complete. Once that's done, we can remove this and go back to a simple
         // query against `FunctionConnection`
         if (!error.message.includes("sObject type 'FunctionsConnection' is not supported.")) {
-          this.handleError(error, flags.json);
+          this.error(error);
         }
         response = await connection.query<FunctionConnectionRecord>(`SELECT
             Id,

--- a/src/commands/env/create/compute.ts
+++ b/src/commands/env/create/compute.ts
@@ -86,14 +86,14 @@ export default class EnvCreateCompute extends Command {
           Id,
           Status,
           Error
-          FROM SfFunctionsConnection`);
+          FROM FunctionsConnection`);
       } catch (err) {
         const error = err as Error;
-        // This is obviously heinous, but should only exist short-term until the move from `SfFunctionsConnection`
+        // This is obviously heinous, but should only exist short-term until the move from `FunctionsConnection`
         // to `FunctionConnection` is complete. Once that's done, we can remove this and go back to a simple
         // query against `FunctionConnection`
-        if (!error.message.includes("sObject type 'SfFunctionsConnection' is not supported.")) {
-          this.error(error);
+        if (!error.message.includes("sObject type 'FunctionsConnection' is not supported.")) {
+          this.handleError(error, flags.json);
         }
         response = await connection.query<FunctionConnectionRecord>(`SELECT
             Id,

--- a/test/commands/env/create/compute.test.ts
+++ b/test/commands/env/create/compute.test.ts
@@ -255,8 +255,8 @@ describe('sf env create compute', () => {
     .add('queryStub', () => {
       const queryStub = sinon.stub();
       queryStub
-        .withArgs(sinon.match('SfFunctionsConnection'))
-        .throws({ message: "sObject type 'SfFunctionsConnection' is not supported." });
+        .withArgs(sinon.match('FunctionsConnection'))
+        .throws({ message: "sObject type 'FunctionsConnection' is not supported." });
 
       queryStub.withArgs(sinon.match('FunctionConnection')).returns({
         records: [
@@ -293,7 +293,7 @@ describe('sf env create compute', () => {
         .reply(200, APP_MOCK);
     })
     .command(['env:create:compute', '-o', `${ORG_ALIAS}`, '-a', `${ENVIRONMENT_ALIAS}`])
-    .it('still creates a compute env even if SfFunctionsConnection is not supported', (ctx) => {
+    .it('still creates a compute env even if FunctionsConnection is not supported', (ctx) => {
       expect(ctx.stderr).to.contain(`Creating compute environment for org ID ${ORG_MOCK.id}`);
       expect(ctx.stdout).to.contain(`New compute environment created with ID ${APP_MOCK.name}`);
       expect(ctx.stdout).to.contain(`Your compute environment with local alias ${ENVIRONMENT_ALIAS} is ready`);


### PR DESCRIPTION
### What does this PR do?
Rename references in CLI for SfFunctionsConnection to FunctionConnection
### What issues does this PR fix or reference?

[@@W-9559660@@](https://gus.lightning.force.com/lightning/r/a07AH000000QOqcYAG/view)