### PR TITLE
fix: update function-core to 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@heroku/eventsource": "^1.0.7",
     "@heroku/function-toml": "^0.0.3",
     "@heroku/project-descriptor": "0.0.6",
-    "@hk/functions-core": "npm:@heroku/functions-core@0.3.1",
+    "@hk/functions-core": "npm:@heroku/functions-core@0.3.2",
     "@oclif/core": "^1.6.0",
     "@salesforce/core": "^3.19.4",
     "@salesforce/plugin-org": "^1.11.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -449,10 +449,10 @@
     ajv-formats "^2.0.2"
     toml "^3.0.0"
 
-"@hk/functions-core@npm:@heroku/functions-core@0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@heroku/functions-core/-/functions-core-0.3.1.tgz#239eba5be5df1e3c5a021e0a629a68b7010ef551"
-  integrity sha512-8/7vO3QDCAbmg/Us47jtvlAR3m2zXTD6b1ocoCFcp40SHBBCRtLgpjRpUgzgtiZgOE4zbUWEadFIZSabrEO8cQ==
+"@hk/functions-core@npm:@heroku/functions-core@0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@heroku/functions-core/-/functions-core-0.3.2.tgz#9f68935250de9ecb9c3ccf69a0bad0e62d60303e"
+  integrity sha512-X4MybSJMYPrGEl29v+QzqhZDWYLAeUWHMziVMwrmWEsDfMJVNSi2YWSg9tqaIvts6+iIhJiIzkNnxMm/2WrSMg==
   dependencies:
     "@heroku-cli/color" "^1.1.14"
     "@heroku/project-descriptor" "0.0.5"


### PR DESCRIPTION
### What does this PR do?

Bumps @hk/functions-core to 0.3.2
* updates sf-fx-runtime-nodejs to 0.11.2
* The primary change included in this release is https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/357

### What issues does this PR fix or reference?

[W-11388878](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE000010lxrzYAA)

@W-11388878@