### PR TITLE
fix: remove short flag -j for json and return response to global json handler

### DIFF
--- a/src/commands/deploy/functions.ts
+++ b/src/commands/deploy/functions.ts
@@ -53,7 +53,6 @@ export default class DeployFunctions extends Command {
       description: messages.getMessage('flags.quiet.summary'),
       char: 'q',
     }),
-    json: FunctionsFlagBuilder.json,
   };
 
   async run() {

--- a/src/commands/deploy/functions.ts
+++ b/src/commands/deploy/functions.ts
@@ -190,13 +190,7 @@ export default class DeployFunctions extends Command {
       cli.exit(1);
     }
     if (flags.json) {
-      cli.styledJSON({
-        status: 0,
-        result: {
-          results,
-        },
-        warnings: [],
-      });
+      return results;
     }
   }
 }

--- a/src/commands/deploy/functions.ts
+++ b/src/commands/deploy/functions.ts
@@ -187,10 +187,9 @@ export default class DeployFunctions extends Command {
     cli.action.stop();
 
     if (shouldExitNonZero) {
-      cli.exit(1);
+      this.exit(1);
     }
-    if (flags.json) {
-      return results;
-    }
+
+    return results;
   }
 }

--- a/src/commands/env/compute/collaborator/add.ts
+++ b/src/commands/env/compute/collaborator/add.ts
@@ -16,6 +16,8 @@ Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-functions', 'env.compute.collaborator.add');
 
 export default class ComputeCollaboratorAdd extends Command {
+  static enableJsonFlag = false;
+
   static summary = messages.getMessage('summary');
 
   static examples = messages.getMessages('examples');

--- a/src/commands/env/create/compute.ts
+++ b/src/commands/env/create/compute.ts
@@ -37,7 +37,6 @@ export default class EnvCreateCompute extends Command {
       char: 'a',
       description: messages.getMessage('flags.alias.summary'),
     }),
-    json: FunctionsFlagBuilder.json,
   };
 
   async run() {

--- a/src/commands/env/create/compute.ts
+++ b/src/commands/env/create/compute.ts
@@ -181,17 +181,13 @@ export default class EnvCreateCompute extends Command {
     }
     const app = await fetchAppForProject(this.client, projectName, org.getUsername());
     if (flags.json) {
-      cli.styledJSON({
-        status: 0,
-        result: {
-          alias,
-          projectName,
-          connectedOrgAlias: '',
-          connectedOrgId: orgId,
-          computeEnvironmentName: app.name,
-        },
-        warnings: [],
-      });
+      return {
+        alias,
+        projectName,
+        connectedOrgAlias: '',
+        connectedOrgId: orgId,
+        computeEnvironmentName: app.name,
+      };
     }
   }
 }

--- a/src/commands/env/create/compute.ts
+++ b/src/commands/env/create/compute.ts
@@ -63,9 +63,7 @@ export default class EnvCreateCompute extends Command {
           )} to the "features" list in your scratch org definition JSON file, e.g. "features": ["Functions"]`
       );
     }
-    if (!flags.json) {
-      cli.action.start(`Creating compute environment for org ID ${orgId}`);
-    }
+    cli.action.start(`Creating compute environment for org ID ${orgId}`);
     const project = await fetchSfdxProject();
     const projectName = project.name;
 
@@ -139,11 +137,9 @@ export default class EnvCreateCompute extends Command {
 
       cli.action.stop();
 
-      if (!flags.json) {
-        this.log(`New compute environment created with ID ${app.name}`);
+      this.log(`New compute environment created with ID ${app.name}`);
 
-        cli.action.start('Connecting environments');
-      }
+      cli.action.start('Connecting environments');
 
       if (alias) {
         this.stateAggregator.aliases.set(alias, app.id!);
@@ -151,13 +147,11 @@ export default class EnvCreateCompute extends Command {
       }
 
       cli.action.stop();
-      if (!flags.json) {
-        this.log(
-          alias
-            ? `Your compute environment with local alias ${herokuColor.cyan(alias)} is ready.`
-            : 'Your compute environment is ready.'
-        );
-      }
+      this.log(
+        alias
+          ? `Your compute environment with local alias ${herokuColor.cyan(alias)} is ready.`
+          : 'Your compute environment is ready.'
+      );
     } catch (err) {
       const DUPLICATE_PROJECT_MESSAGE =
         'There is already a project with the same name in the same namespace for this org';
@@ -180,14 +174,12 @@ export default class EnvCreateCompute extends Command {
       this.error(`${error.data.message}`);
     }
     const app = await fetchAppForProject(this.client, projectName, org.getUsername());
-    if (flags.json) {
-      return {
-        alias,
-        projectName,
-        connectedOrgAlias: '',
-        connectedOrgId: orgId,
-        computeEnvironmentName: app.name,
-      };
-    }
+    return {
+      alias,
+      projectName,
+      connectedOrgAlias: '',
+      connectedOrgId: orgId,
+      computeEnvironmentName: app.name,
+    };
   }
 }

--- a/src/commands/env/delete.ts
+++ b/src/commands/env/delete.ts
@@ -158,11 +158,7 @@ export default class EnvDelete extends Command {
     cli.action.stop();
 
     if (flags.json) {
-      cli.styledJSON({
-        status: 0,
-        result: 'Environment deleted.',
-        warnings: [],
-      });
+      return 'Environment deleted.';
     }
   }
 }

--- a/src/commands/env/delete.ts
+++ b/src/commands/env/delete.ts
@@ -58,7 +58,7 @@ export default class EnvDelete extends Command {
     }
 
     if (flags.environment) {
-      cli.warn(messages.getMessage('flags.environment.deprecation'));
+      this.warn(messages.getMessage('flags.environment.deprecation'));
     }
 
     await this.confirmRemovePrompt('environment', targetCompute, flags.confirm);
@@ -157,8 +157,6 @@ export default class EnvDelete extends Command {
 
     cli.action.stop();
 
-    if (flags.json) {
-      return 'Environment deleted.';
-    }
+    return 'Environment deleted.';
   }
 }

--- a/src/commands/env/delete.ts
+++ b/src/commands/env/delete.ts
@@ -40,7 +40,6 @@ export default class EnvDelete extends Command {
       hidden: true,
     }),
     confirm: confirmationFlag,
-    json: FunctionsFlagBuilder.json,
   };
 
   async run() {

--- a/src/commands/env/log.ts
+++ b/src/commands/env/log.ts
@@ -56,7 +56,7 @@ export default class Log extends Command {
     }
 
     if (flags.environment) {
-      cli.warn(messages.getMessage('flags.environment.deprecation'));
+      this.warn(messages.getMessage('flags.environment.deprecation'));
     }
 
     const appName = await resolveAppNameForEnvironment(targetCompute);

--- a/src/commands/env/log.ts
+++ b/src/commands/env/log.ts
@@ -19,6 +19,8 @@ const messages = Messages.loadMessages('@salesforce/plugin-functions', 'env.log'
 
 export default class Log extends Command {
   public static readonly state = 'beta';
+  static enableJsonFlag = false;
+
   static summary = messages.getMessage('summary');
 
   static examples = messages.getMessages('examples');

--- a/src/commands/env/log/tail.ts
+++ b/src/commands/env/log/tail.ts
@@ -50,7 +50,7 @@ export default class LogTail extends Command {
     }
 
     if (flags.environment) {
-      cli.warn(messages.getMessage('flags.environment.deprecation'));
+      this.warn(messages.getMessage('flags.environment.deprecation'));
     }
 
     const appName = await resolveAppNameForEnvironment(targetCompute);

--- a/src/commands/env/log/tail.ts
+++ b/src/commands/env/log/tail.ts
@@ -18,6 +18,8 @@ Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-functions', 'env.log.tail');
 
 export default class LogTail extends Command {
+  static enableJsonFlag = false;
+
   static summary = messages.getMessage('summary');
 
   static examples = messages.getMessages('examples');

--- a/src/commands/env/logdrain/add.ts
+++ b/src/commands/env/logdrain/add.ts
@@ -86,20 +86,16 @@ export default class LogDrainAdd extends Command {
       });
 
       if (flags.json) {
-        cli.styledJSON({
-          status: 0,
-          result: [
-            {
-              addon: null,
-              created_at: result.data.created_at,
-              id: result.data.id,
-              token: result.data.token,
-              updated_at: result.data.updated_at,
-              url: result.data.url,
-            },
-          ],
-          warnings: [],
-        });
+        return [
+          {
+            addon: null,
+            created_at: result.data.created_at,
+            id: result.data.id,
+            token: result.data.token,
+            updated_at: result.data.updated_at,
+            url: result.data.url,
+          },
+        ];
       } else {
         cli.action.start(`Creating drain for environment ${herokuColor.app(targetCompute)}`);
 

--- a/src/commands/env/logdrain/add.ts
+++ b/src/commands/env/logdrain/add.ts
@@ -43,7 +43,6 @@ export default class LogDrainAdd extends Command {
       description: messages.getMessage('flags.drain-url.summary'),
       hidden: true,
     }),
-    json: FunctionsFlagBuilder.json,
   };
 
   async run() {

--- a/src/commands/env/logdrain/add.ts
+++ b/src/commands/env/logdrain/add.ts
@@ -70,54 +70,52 @@ export default class LogDrainAdd extends Command {
     }
 
     if (flags.environment) {
-      cli.warn(messages.getMessage('flags.environment.deprecation'));
+      this.warn(messages.getMessage('flags.environment.deprecation'));
     }
 
     if (flags.url) {
-      cli.warn(messages.getMessage('flags.url.deprecation'));
+      this.warn(messages.getMessage('flags.url.deprecation'));
     }
     const appName = await resolveAppNameForEnvironment(targetCompute);
 
     try {
+      cli.action.start(`Creating drain for environment ${herokuColor.app(targetCompute)}`);
+
       const result = await this.client.post<Heroku.LogDrain>(`/apps/${appName}/log-drains`, {
         data: {
           url,
         },
       });
 
-      if (flags.json) {
-        return [
-          {
-            addon: null,
-            created_at: result.data.created_at,
-            id: result.data.id,
-            token: result.data.token,
-            updated_at: result.data.updated_at,
-            url: result.data.url,
-          },
-        ];
-      } else {
-        cli.action.start(`Creating drain for environment ${herokuColor.app(targetCompute)}`);
+      cli.action.stop();
 
-        cli.action.stop();
-      }
+      return [
+        {
+          addon: null,
+          created_at: result.data.created_at,
+          id: result.data.id,
+          token: result.data.token,
+          updated_at: result.data.updated_at,
+          url: result.data.url,
+        },
+      ];
     } catch (e) {
       const error = e as { data: { message?: string } };
 
       if (error.data?.message?.includes('Url is invalid')) {
-        this.error(new Error(`URL is invalid <${url}>`));
+        this.error(new Error(`URL is invalid ${url}`));
       }
 
       if (error.data?.message?.includes('Url has already been taken')) {
-        this.error(new Error(`Logdrain URL is already added <${url}>`));
+        this.error(new Error(`Logdrain URL is already added ${url}`));
       }
 
-      if (error.data?.message?.includes("Couldn't find that app.")) {
-        this.error(new Error(`Could not find environment <${appName}>`));
+      if (error.data?.message?.includes("Couldn't find that app")) {
+        this.error(new Error(`Could not find environment ${appName}`));
       }
 
       if (error.data?.message?.includes("You've reached the limit")) {
-        this.error(new Error(`You've reached the limit of 5 log drains on <${appName}>`));
+        this.error(new Error(`You've reached the limit of 5 log drains on ${appName}`));
       }
 
       if (error.data?.message?.includes('401')) {

--- a/src/commands/env/logdrain/list.ts
+++ b/src/commands/env/logdrain/list.ts
@@ -57,43 +57,32 @@ export default class LogDrainList extends Command {
 
     if (flags.json) {
       if (drains.length === 0) {
-        cli.styledJSON({
-          status: 0,
-          result: [],
-          warnings: [`No logdrain found for environment <${appName}>`],
-        });
-        return;
+        this.warn(`No logdrain found for environment <${appName}>`);
       }
 
-      cli.styledJSON({
-        status: 0,
-        result: drains,
-        warnings: [],
-      });
-      return;
+      return drains;
     } else {
       if (drains.length === 0) {
         this.log(`No log drains found for environment ${targetCompute}.`);
-        return;
+      } else {
+        cli.table<Heroku.LogDrain>(
+          drains,
+          {
+            id: {
+              header: 'ID',
+              get: (row) => row.id,
+            },
+            url: {
+              header: 'URL',
+              get: (row) => row.url,
+            },
+          },
+          {
+            printLine: this.log.bind(this),
+            ...flags,
+          }
+        );
       }
-
-      cli.table<Heroku.LogDrain>(
-        drains,
-        {
-          id: {
-            header: 'ID',
-            get: (row) => row.id,
-          },
-          url: {
-            header: 'URL',
-            get: (row) => row.url,
-          },
-        },
-        {
-          printLine: this.log.bind(this),
-          ...flags,
-        }
-      );
     }
   }
 }

--- a/src/commands/env/logdrain/list.ts
+++ b/src/commands/env/logdrain/list.ts
@@ -30,7 +30,6 @@ export default class LogDrainList extends Command {
       exclusive: ['target-compute'],
       hidden: true,
     }),
-    json: FunctionsFlagBuilder.json,
   };
 
   async run() {

--- a/src/commands/env/logdrain/list.ts
+++ b/src/commands/env/logdrain/list.ts
@@ -48,41 +48,35 @@ export default class LogDrainList extends Command {
     }
 
     if (flags.environment) {
-      cli.warn(messages.getMessage('flags.environment.deprecation'));
+      this.warn(messages.getMessage('flags.environment.deprecation'));
     }
 
     const appName = await resolveAppNameForEnvironment(targetCompute);
 
     const { data: drains } = await this.client.get<Heroku.LogDrain[]>(`/apps/${appName}/log-drains`);
 
-    if (flags.json) {
-      if (drains.length === 0) {
-        this.warn(`No logdrain found for environment <${appName}>`);
-      }
-
-      return drains;
+    if (drains.length === 0) {
+      this.warn(`No log-drains found for environment ${targetCompute}`);
     } else {
-      if (drains.length === 0) {
-        this.log(`No log drains found for environment ${targetCompute}.`);
-      } else {
-        cli.table<Heroku.LogDrain>(
-          drains,
-          {
-            id: {
-              header: 'ID',
-              get: (row) => row.id,
-            },
-            url: {
-              header: 'URL',
-              get: (row) => row.url,
-            },
+      cli.table<Heroku.LogDrain>(
+        drains,
+        {
+          id: {
+            header: 'ID',
+            get: (row) => row.id,
           },
-          {
-            printLine: this.log.bind(this),
-            ...flags,
-          }
-        );
-      }
+          url: {
+            header: 'URL',
+            get: (row) => row.url,
+          },
+        },
+        {
+          printLine: this.log.bind(this),
+          ...flags,
+        }
+      );
     }
+
+    return drains;
   }
 }

--- a/src/commands/env/logdrain/remove.ts
+++ b/src/commands/env/logdrain/remove.ts
@@ -43,7 +43,6 @@ export default class LogDrainRemove extends Command {
       description: messages.getMessage('flags.drain-url.summary'),
       hidden: true,
     }),
-    json: FunctionsFlagBuilder.json,
   };
 
   async run() {

--- a/src/commands/env/logdrain/remove.ts
+++ b/src/commands/env/logdrain/remove.ts
@@ -77,12 +77,7 @@ export default class LogDrainRemove extends Command {
     try {
       await this.client.delete<Heroku.LogDrain>(`/apps/${appName}/log-drains/${encodeURIComponent(url)}`);
       if (flags.json) {
-        cli.styledJSON({
-          status: 0,
-          result: null,
-          warnings: [],
-        });
-        return;
+        return [];
       } else {
         cli.action.start(`Deleting drain for environment ${herokuColor.app(targetCompute)}`);
 

--- a/src/commands/env/logdrain/remove.ts
+++ b/src/commands/env/logdrain/remove.ts
@@ -66,32 +66,31 @@ export default class LogDrainRemove extends Command {
     }
 
     if (flags.environment) {
-      cli.warn(messages.getMessage('flags.environment.deprecation'));
+      this.warn(messages.getMessage('flags.environment.deprecation'));
     }
 
     if (flags.url) {
-      cli.warn(messages.getMessage('flags.url.deprecation'));
+      this.warn(messages.getMessage('flags.url.deprecation'));
     }
 
     const appName = await resolveAppNameForEnvironment(targetCompute);
     try {
-      await this.client.delete<Heroku.LogDrain>(`/apps/${appName}/log-drains/${encodeURIComponent(url)}`);
-      if (flags.json) {
-        return [];
-      } else {
-        cli.action.start(`Deleting drain for environment ${herokuColor.app(targetCompute)}`);
+      cli.action.start(`Deleting drain for environment ${herokuColor.app(targetCompute)}`);
 
-        cli.action.stop();
-      }
+      await this.client.delete<Heroku.LogDrain>(`/apps/${appName}/log-drains/${encodeURIComponent(url)}`);
+
+      cli.action.stop();
+
+      return [];
     } catch (e) {
       const error = e as { data: { message?: string } };
 
       if (error.data?.message?.includes('Url is invalid')) {
-        this.error(new Error(`URL is invalid <${url}>`));
+        this.error(new Error(`URL is invalid ${url}`));
       }
 
       if (error.data?.message?.includes("Couldn't find that app.")) {
-        this.error(new Error(`Couldn't find that app  <${appName}>`));
+        this.error(new Error(`Couldn't find that app  ${appName}`));
       }
 
       this.error(e as Error);

--- a/src/commands/env/logdrain/remove.ts
+++ b/src/commands/env/logdrain/remove.ts
@@ -62,7 +62,7 @@ export default class LogDrainRemove extends Command {
     }
 
     if (!url) {
-      this.error(new Error('Missing required flag: -u, --url Logdrain url to remove'));
+      this.error(new Error('Missing required flag: -l, --drain-url Logdrain url to remove'));
     }
 
     if (flags.environment) {
@@ -81,7 +81,7 @@ export default class LogDrainRemove extends Command {
 
       cli.action.stop();
 
-      return [];
+      return 'Removed drain-url';
     } catch (e) {
       const error = e as { data: { message?: string } };
 

--- a/src/commands/env/var/get.ts
+++ b/src/commands/env/var/get.ts
@@ -69,19 +69,11 @@ export default class VarGet extends Command {
 
     if (flags.json) {
       if (!value) {
-        cli.styledJSON({
-          status: 0,
-          result: null,
-          warnings: [`No config var named ${args.key as string} found for environment <${targetCompute}>`],
-        });
-        return;
+        this.warn(`No config var named ${args.key as string} found for environment <${targetCompute}>`);
+        return []; // Can't return falsy to json handler
       }
 
-      cli.styledJSON({
-        status: 0,
-        result: value,
-        warnings: [],
-      });
+      return value;
     } else {
       if (!value) {
         cli.warn(
@@ -89,8 +81,9 @@ export default class VarGet extends Command {
             targetCompute
           )}`
         );
+      } else {
+        this.log(value);
       }
-      this.log(value);
     }
   }
 }

--- a/src/commands/env/var/get.ts
+++ b/src/commands/env/var/get.ts
@@ -58,7 +58,7 @@ export default class VarGet extends Command {
     }
 
     if (flags.environment) {
-      cli.warn(messages.getMessage('flags.environment.deprecation'));
+      this.warn(messages.getMessage('flags.environment.deprecation'));
     }
 
     const appName = await resolveAppNameForEnvironment(targetCompute);
@@ -67,23 +67,20 @@ export default class VarGet extends Command {
 
     const value = config[args.key];
 
-    if (flags.json) {
-      if (!value) {
-        this.warn(`No config var named ${args.key as string} found for environment <${targetCompute}>`);
-        return []; // Can't return falsy to json handler
-      }
-
-      return value;
-    } else {
-      if (!value) {
-        cli.warn(
+    if (!value) {
+      if (flags.json) {
+        this.warn(`No config var named ${args.key as string} found for environment ${targetCompute}`);
+      } else {
+        this.warn(
           `No config var named ${herokuColor.cyan(args.key as string)} found for environment ${herokuColor.cyan(
             targetCompute
           )}`
         );
-      } else {
-        this.log(value);
       }
+    } else {
+      this.log(value);
     }
+
+    return value || []; // can't return falsy to json handler
   }
 }

--- a/src/commands/env/var/get.ts
+++ b/src/commands/env/var/get.ts
@@ -33,7 +33,6 @@ export default class VarGet extends Command {
       exclusive: ['target-compute'],
       hidden: true,
     }),
-    json: FunctionsFlagBuilder.json,
   };
 
   static args = [

--- a/src/commands/env/var/list.ts
+++ b/src/commands/env/var/list.ts
@@ -66,43 +66,33 @@ export default class ConfigList extends Command {
     });
 
     if (flags.json) {
-      if (!configArray.length) {
-        cli.styledJSON({
-          status: 0,
-          result: [],
-          warnings: [`No config vars found for environment <${targetCompute}>`],
-        });
-        return;
+      if (configArray.length === 0) {
+        this.warn(`No config vars found for environment <${targetCompute}>`);
       }
 
-      cli.styledJSON({
-        status: 0,
-        result: config,
-        warnings: [],
-      });
+      return config;
     } else {
       if (!configArray.length) {
         cli.warn(`No config vars found for environment ${targetCompute}`);
-        return;
+      } else {
+        cli.table(
+          configArray,
+          {
+            key: {
+              header: 'Key',
+              get: (configVar) => configVar.key,
+            },
+            value: {
+              header: 'Value',
+              get: (configVar) => configVar.value,
+            },
+          },
+          {
+            printLine: this.log.bind(this),
+            ...flags,
+          }
+        );
       }
-
-      cli.table(
-        configArray,
-        {
-          key: {
-            header: 'Key',
-            get: (configVar) => configVar.key,
-          },
-          value: {
-            header: 'Value',
-            get: (configVar) => configVar.value,
-          },
-        },
-        {
-          printLine: this.log.bind(this),
-          ...flags,
-        }
-      );
     }
   }
 }

--- a/src/commands/env/var/list.ts
+++ b/src/commands/env/var/list.ts
@@ -33,7 +33,6 @@ export default class ConfigList extends Command {
       exclusive: ['target-compute'],
       hidden: true,
     }),
-    json: FunctionsFlagBuilder.json,
   };
 
   async run() {

--- a/src/commands/env/var/list.ts
+++ b/src/commands/env/var/list.ts
@@ -51,7 +51,7 @@ export default class ConfigList extends Command {
     }
 
     if (flags.environment) {
-      cli.warn(messages.getMessage('flags.environment.deprecation'));
+      this.warn(messages.getMessage('flags.environment.deprecation'));
     }
 
     const appName = await resolveAppNameForEnvironment(targetCompute);
@@ -65,34 +65,27 @@ export default class ConfigList extends Command {
       };
     });
 
-    if (flags.json) {
-      if (configArray.length === 0) {
-        this.warn(`No config vars found for environment <${targetCompute}>`);
-      }
-
-      return config;
+    if (configArray.length === 0) {
+      this.warn(`No config vars found for environment ${targetCompute}`);
     } else {
-      if (!configArray.length) {
-        cli.warn(`No config vars found for environment ${targetCompute}`);
-      } else {
-        cli.table(
-          configArray,
-          {
-            key: {
-              header: 'Key',
-              get: (configVar) => configVar.key,
-            },
-            value: {
-              header: 'Value',
-              get: (configVar) => configVar.value,
-            },
+      cli.table(
+        configArray,
+        {
+          key: {
+            header: 'Key',
+            get: (configVar) => configVar.key,
           },
-          {
-            printLine: this.log.bind(this),
-            ...flags,
-          }
-        );
-      }
+          value: {
+            header: 'Value',
+            get: (configVar) => configVar.value,
+          },
+        },
+        {
+          printLine: this.log.bind(this),
+          ...flags,
+        }
+      );
     }
+    return config;
   }
 }

--- a/src/commands/env/var/set.ts
+++ b/src/commands/env/var/set.ts
@@ -68,7 +68,7 @@ export default class ConfigSet extends Command {
     }
 
     if (flags.environment) {
-      cli.warn(messages.getMessage('flags.environment.deprecation'));
+      this.warn(messages.getMessage('flags.environment.deprecation'));
     }
 
     const appName = await resolveAppNameForEnvironment(targetCompute);
@@ -92,7 +92,7 @@ export default class ConfigSet extends Command {
     } catch (error: any) {
       cli.action.stop('failed');
       if (error.data?.message?.includes("Couldn't find that app")) {
-        this.error(new Error(`Could not find environment <${appName}>`));
+        this.error(new Error(`Could not find environment ${appName}`));
       }
       this.error(error);
     }

--- a/src/commands/env/var/set.ts
+++ b/src/commands/env/var/set.ts
@@ -130,12 +130,7 @@ export default class ConfigSet extends Command {
           data: configPairs,
         });
 
-        cli.styledJSON({
-          status: 0,
-          result: null,
-          warnings: [],
-        });
-        return;
+        return [];
       } catch (err: any) {
         this.parseErrors(err, targetCompute);
       }

--- a/src/commands/env/var/set.ts
+++ b/src/commands/env/var/set.ts
@@ -32,7 +32,6 @@ export default class ConfigSet extends Command {
       exclusive: ['target-compute'],
       hidden: true,
     }),
-    json: FunctionsFlagBuilder.json,
   };
 
   parseKeyValuePairs(pairs: string[]) {

--- a/src/commands/env/var/set.ts
+++ b/src/commands/env/var/set.ts
@@ -88,7 +88,7 @@ export default class ConfigSet extends Command {
 
       cli.action.stop();
 
-      return [];
+      return 'Set env var';
     } catch (error: any) {
       cli.action.stop('failed');
       if (error.data?.message?.includes("Couldn't find that app")) {

--- a/src/commands/env/var/unset.ts
+++ b/src/commands/env/var/unset.ts
@@ -102,6 +102,6 @@ export default class ConfigUnset extends Command {
 
     cli.action.stop();
 
-    return [];
+    return 'Unset env var';
   }
 }

--- a/src/commands/env/var/unset.ts
+++ b/src/commands/env/var/unset.ts
@@ -35,7 +35,6 @@ export default class ConfigUnset extends Command {
       exclusive: ['target-compute'],
       hidden: true,
     }),
-    json: FunctionsFlagBuilder.json,
   };
 
   async run() {

--- a/src/commands/env/var/unset.ts
+++ b/src/commands/env/var/unset.ts
@@ -106,11 +106,7 @@ export default class ConfigUnset extends Command {
     }
 
     if (flags.json) {
-      cli.styledJSON({
-        status: 0,
-        result: null,
-        warnings: [],
-      });
+      return [];
     }
   }
 }

--- a/src/commands/env/var/unset.ts
+++ b/src/commands/env/var/unset.ts
@@ -53,7 +53,7 @@ export default class ConfigUnset extends Command {
     }
 
     if (flags.environment) {
-      cli.warn(messages.getMessage('flags.environment.deprecation'));
+      this.warn(messages.getMessage('flags.environment.deprecation'));
     }
 
     if (argv.length === 0) {
@@ -73,10 +73,10 @@ export default class ConfigUnset extends Command {
       const error = e as Error;
 
       if (error.message?.includes('not correct config var')) {
-        this.error(new Error(`Value provided for key does not match a config var found for <${appName}>.`));
+        this.error(new Error(`Value provided for key does not match a config var found for ${appName}`));
       }
       if (error.message?.includes('404')) {
-        this.error(new Error(`Couldn't find that app <${appName}>`));
+        this.error(new Error(`Couldn't find that app ${appName}`));
       }
       if (error.message?.includes('401')) {
         this.error(new Error('Your token has expired, please login with sf login functions'));
@@ -91,22 +91,17 @@ export default class ConfigUnset extends Command {
       };
     }, {});
 
+    const message = `Unsetting ${Object.keys(configPairs)
+      .map((key) => herokuColor.configVar(key))
+      .join(', ')} and restarting ${herokuColor.app(targetCompute)}`;
+    cli.action.start(message);
+
     await this.client.patch(`/apps/${appName}/config-vars`, {
       data: configPairs,
     });
 
-    if (!flags.json) {
-      cli.action.start(
-        `Unsetting ${Object.keys(configPairs)
-          .map((key) => herokuColor.configVar(key))
-          .join(', ')} and restarting ${herokuColor.app(targetCompute)}`
-      );
+    cli.action.stop();
 
-      cli.action.stop();
-    }
-
-    if (flags.json) {
-      return [];
-    }
+    return [];
   }
 }

--- a/src/commands/generate/function.ts
+++ b/src/commands/generate/function.ts
@@ -59,7 +59,7 @@ export default class GenerateFunction extends Command {
     }
 
     if (flags.name) {
-      cli.warn(messages.getMessage('flags.name.deprecation'));
+      this.warn(messages.getMessage('flags.name.deprecation'));
     }
 
     const { name, path, language, welcomeText } = await generateFunction(fnName, flags.language as Language);

--- a/src/commands/generate/function.ts
+++ b/src/commands/generate/function.ts
@@ -18,6 +18,8 @@ const messages = Messages.loadMessages('@salesforce/plugin-functions', 'generate
  * Based on given language, create function project with specific scaffolding.
  */
 export default class GenerateFunction extends Command {
+  static enableJsonFlag = false;
+
   static summary = messages.getMessage('summary');
 
   static description = messages.getMessage('description');

--- a/src/commands/login/functions/jwt.ts
+++ b/src/commands/login/functions/jwt.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { Flags } from '@oclif/core';
-import { AuthInfo, AuthRemover, SfdxError, Messages } from '@salesforce/core';
+import { AuthInfo, AuthRemover, Messages } from '@salesforce/core';
 import { getString } from '@salesforce/ts-types';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -14,7 +14,6 @@ import { cli } from 'cli-ux';
 import Command from '../../../lib/base';
 import { herokuVariant } from '../../../lib/heroku-variant';
 import { fetchSfdxProject } from '../../../lib/utils';
-import { FunctionsFlagBuilder } from '../../../lib/flags';
 
 // This is a public Oauth client created expressly for the purpose of headless auth in the functions CLI.
 // It does not require a client secret, is marked as public in the database and scoped accordingly
@@ -209,21 +208,17 @@ export default class JwtLogin extends Command {
 
     await this.stateAggregator.tokens.write();
 
-    if (flags.json) {
-      cli.styledJSON({
-        status: 0,
-        result: {
-          username: authFields.username,
-          sfdxAccessToken: token,
-          functionsAccessToken: bearerToken,
-          instanceUrl: authFields.instanceUrl,
-          orgId: authFields.orgId,
-          privateKey: authFields.privateKey,
-        },
-        warnings: [],
-      });
-    }
-
     cli.action.stop();
+
+    if (flags.json) {
+      return {
+        username: authFields.username,
+        sfdxAccessToken: token,
+        functionsAccessToken: bearerToken,
+        instanceUrl: authFields.instanceUrl,
+        orgId: authFields.orgId,
+        privateKey: authFields.privateKey,
+      };
+    }
   }
 }

--- a/src/commands/login/functions/jwt.ts
+++ b/src/commands/login/functions/jwt.ts
@@ -140,7 +140,7 @@ export default class JwtLogin extends Command {
     const instanceUrl = flags['instance-url'] ?? flags.instanceurl;
 
     if (flags.instanceurl) {
-      cli.warn(messages.getMessage('flags.instanceurl.deprecation'));
+      this.warn(messages.getMessage('flags.instanceurl.deprecation'));
     }
 
     cli.action.start('Logging in via JWT');
@@ -210,15 +210,13 @@ export default class JwtLogin extends Command {
 
     cli.action.stop();
 
-    if (flags.json) {
-      return {
-        username: authFields.username,
-        sfdxAccessToken: token,
-        functionsAccessToken: bearerToken,
-        instanceUrl: authFields.instanceUrl,
-        orgId: authFields.orgId,
-        privateKey: authFields.privateKey,
-      };
-    }
+    return {
+      username: authFields.username,
+      sfdxAccessToken: token,
+      functionsAccessToken: bearerToken,
+      instanceUrl: authFields.instanceUrl,
+      orgId: authFields.orgId,
+      privateKey: authFields.privateKey,
+    };
   }
 }

--- a/src/commands/login/functions/jwt.ts
+++ b/src/commands/login/functions/jwt.ts
@@ -72,7 +72,6 @@ export default class JwtLogin extends Command {
       exclusive: ['instance-url'],
       hidden: true,
     }),
-    json: FunctionsFlagBuilder.json,
     alias: Flags.string({
       char: 'a',
       description: messages.getMessage('flags.alias.summary'),

--- a/src/commands/logout/functions.ts
+++ b/src/commands/logout/functions.ts
@@ -30,12 +30,9 @@ export default class Login extends Command {
     await this.stateAggregator.tokens.write();
 
     cli.action.stop();
+
     if (flags.json) {
-      cli.styledJSON({
-        status: 0,
-        result: [],
-        warnings: [],
-      });
+      return [];
     }
   }
 }

--- a/src/commands/logout/functions.ts
+++ b/src/commands/logout/functions.ts
@@ -31,8 +31,6 @@ export default class Login extends Command {
 
     cli.action.stop();
 
-    if (flags.json) {
-      return [];
-    }
+    return [];
   }
 }

--- a/src/commands/logout/functions.ts
+++ b/src/commands/logout/functions.ts
@@ -8,7 +8,6 @@ import { cli } from 'cli-ux';
 import { Messages } from '@salesforce/core';
 
 import Command from '../../lib/base';
-import { FunctionsFlagBuilder } from '../../lib/flags';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-functions', 'logout.functions');
@@ -31,6 +30,6 @@ export default class Login extends Command {
 
     cli.action.stop();
 
-    return [];
+    return 'Logged out';
   }
 }

--- a/src/commands/logout/functions.ts
+++ b/src/commands/logout/functions.ts
@@ -18,9 +18,7 @@ export default class Login extends Command {
 
   static examples = messages.getMessages('examples');
 
-  static flags = {
-    json: FunctionsFlagBuilder.json,
-  };
+  static flags = {};
 
   async run() {
     const { flags } = await this.parse(Login);

--- a/src/commands/run/function.ts
+++ b/src/commands/run/function.ts
@@ -66,8 +66,8 @@ export default class Invoke extends Command {
        See more help with --help`
       );
     }
-    if (flags.url && !flags.json) {
-      cli.warn(messages.getMessage('flags.url.deprecation'));
+    if (flags.url) {
+      this.warn(messages.getMessage('flags.url.deprecation'));
     }
     flags.payload = await this.getPayloadData(flags.payload);
     if (!flags.payload) {
@@ -76,32 +76,36 @@ export default class Invoke extends Command {
     const aggregator = await ConfigAggregator.create();
     const targetOrg = aggregator.getPropertyValue('target-org');
     if (!flags['connected-org'] && !targetOrg) {
-      cli.warn('No -o connected org or target-org found, context will be partially initialized');
+      this.warn('No -o connected org or target-org found, context will be partially initialized');
     }
     const aliasOrUser = flags['connected-org'] || `target-org ${targetOrg}`;
-    if (!flags.json) {
-      cli.log(`Using ${aliasOrUser} login credential to initialize context`);
-      cli.action.start(`${herokuColor.cyanBright('POST')} ${url}`);
-    }
+    this.log(`Using ${aliasOrUser} login credential to initialize context`);
+
+    cli.action.start(`${herokuColor.cyanBright('POST')} ${url}`);
+
     const runFunctionOptions = {
       ...flags,
       url,
       targetusername: flags['connected-org'] ?? targetOrg,
     };
 
+    let response;
+
     try {
-      const response = await runFunction(runFunctionOptions as RunFunctionOptions);
-      if (flags.json) {
-        return response.data;
-      } else {
-        cli.action.stop(herokuColor.greenBright(response.status.toString()));
+      response = await runFunction(runFunctionOptions as RunFunctionOptions);
+      cli.action.stop(herokuColor.greenBright(response.status.toString()));
+
+      if (!flags.json) {
         this.writeResponse(response);
       }
+      return response.data;
     } catch (e) {
       const error = e as AxiosError;
+
       if (error.response) {
         this.error(new Error(`${error.response.status} ${error.response.statusText}`));
       }
+
       this.error(new Error(`${error.message}`));
     }
   }
@@ -115,7 +119,7 @@ export default class Invoke extends Command {
   writeResponse(response: AxiosResponse) {
     const contentType = response.headers['content-type'];
     if (contentType.includes('application/json') || contentType.includes('application/cloudevents+json')) {
-      cli.styledJSON(response.data);
+      this.styledJSON(response.data);
     } else {
       this.log(response.data as string);
     }

--- a/src/commands/run/function.ts
+++ b/src/commands/run/function.ts
@@ -52,7 +52,6 @@ export default class Invoke extends Command {
       char: 'o',
       description: messages.getMessage('flags.connected-org.summary'),
     }),
-    json: FunctionsFlagBuilder.json,
   };
 
   async run() {

--- a/src/commands/run/function.ts
+++ b/src/commands/run/function.ts
@@ -92,14 +92,10 @@ export default class Invoke extends Command {
     try {
       const response = await runFunction(runFunctionOptions as RunFunctionOptions);
       if (flags.json) {
-        cli.styledJSON({
-          status: 0,
-          result: response.data,
-          warnings: [],
-        });
+        return response.data;
       } else {
-        this.writeResponse(response);
         cli.action.stop(herokuColor.greenBright(response.status.toString()));
+        this.writeResponse(response);
       }
     } catch (e) {
       const error = e as AxiosError;

--- a/src/commands/run/function/start.ts
+++ b/src/commands/run/function/start.ts
@@ -85,7 +85,7 @@ export default class Start extends Local {
       try {
         msg = messages.getMessage(`flags.${flag}.deprecation`);
         if (val) {
-          cli.warn(msg);
+          this.warn(msg);
         }
       } catch {
         // No deprecation message, flag is not deprecated

--- a/src/commands/run/function/start/container.ts
+++ b/src/commands/run/function/start/container.ts
@@ -116,7 +116,7 @@ export default class Container extends Command {
     benny.on('log', (msg: { text: string; level: string; fields: JsonMap }) => {
       if (msg.level === 'debug' && !flags.verbose) return;
       if (msg.level === 'error') {
-        cli.exit();
+        this.exit();
       }
 
       if (msg.text) {

--- a/src/commands/whoami/functions.ts
+++ b/src/commands/whoami/functions.ts
@@ -33,7 +33,7 @@ export default class WhoAmI extends Command {
     }),
   };
 
-  async run(): Promise<FunctionsInformation> {
+  async run() {
     const { flags } = await this.parse(WhoAmI);
     this.postParseHook(flags);
 
@@ -48,24 +48,16 @@ export default class WhoAmI extends Command {
       });
 
       if (flags['show-token']) {
-        cli.styledJSON({
-          status: 0,
-          result: {
-            functionsEmail: ret['email'],
-            functionsId: ret['id'],
-            functionsToken: this.auth,
-          },
-          warnings: [],
-        });
+        return {
+          functionsEmail: ret['email'],
+          functionsId: ret['id'],
+          functionsToken: this.auth,
+        };
       } else {
-        cli.styledJSON({
-          status: 0,
-          result: {
-            functionsEmail: ret['email'],
-            functionsId: ret['id'],
-          },
-          warnings: [],
-        });
+        return {
+          functionsEmail: ret['email'],
+          functionsId: ret['id'],
+        };
       }
     } else {
       this.log(`Hello ${account.name} 👋 \n`);

--- a/src/commands/whoami/functions.ts
+++ b/src/commands/whoami/functions.ts
@@ -31,7 +31,6 @@ export default class WhoAmI extends Command {
       description: messages.getMessage('flags.show-token.summary'),
       hidden: true,
     }),
-    json: FunctionsFlagBuilder.json,
   };
 
   async run(): Promise<FunctionsInformation> {

--- a/src/lib/base.ts
+++ b/src/lib/base.ts
@@ -16,8 +16,6 @@ import { SfdcAccount } from './sfdc-types';
 export default abstract class Command extends SfCommand<any> {
   protected static TOKEN_BEARER_KEY = 'functions-bearer';
   protected static TOKEN_REFRESH_KEY = 'functions-refresh';
-  // We want to implement `--json` on a per-command basis, so we disable the global json flag here
-  static enableJsonFlag = false;
 
   protected stateAggregator!: StateAggregator;
 

--- a/src/lib/base.ts
+++ b/src/lib/base.ts
@@ -139,7 +139,7 @@ export default abstract class Command extends SfCommand<any> {
     const confirmedValue = this.fetchConfirmationValue(name, confirm);
     if (name !== confirmedValue) {
       warningMessage = warningMessage || `This will delete the ${type} ${name}`;
-      cli.warn(`${warningMessage}\nTo proceed, enter the ${type} name (${name}) again in the prompt below:`);
+      this.warn(`${warningMessage}\nTo proceed, enter the ${type} name (${name}) again in the prompt below:`);
       // This is a workaround for cli-ux
       // & fancy-test stubbing issues
       // cli-ux mocks itself incorrectly (tbd why)
@@ -169,7 +169,7 @@ export default abstract class Command extends SfCommand<any> {
         name,
         warnings: [],
       });
-      cli.exit(1);
+      this.exit(1);
     } else {
       super.error(input, options as any);
     }

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -37,11 +37,6 @@ export const FunctionsFlagBuilder = {
       return { key, value };
     },
   }),
-
-  json: Flags.boolean({
-    description: messages.getMessage('flags.json.summary'),
-    char: 'j',
-  }),
 };
 
 export const environmentType = Flags.string({

--- a/test/commands/env/create/compute.test.ts
+++ b/test/commands/env/create/compute.test.ts
@@ -164,7 +164,7 @@ describe('sf env create compute', () => {
         .get(`/sales-org-connections/${ORG_MOCK.id}/apps/${PROJECT_CONFIG_MOCK.name}`)
         .reply(200, APP_MOCK);
     })
-    .command(['env:create:compute', '-o', `${ORG_ALIAS}`, '-a', `${ENVIRONMENT_ALIAS}`, '-j'])
+    .command(['env:create:compute', '-o', `${ORG_ALIAS}`, '-a', `${ENVIRONMENT_ALIAS}`, '--json'])
     .it('will show json output with success', (ctx) => {
       const succJSON = JSON.parse(ctx.stdout);
 

--- a/test/commands/env/delete.test.ts
+++ b/test/commands/env/delete.test.ts
@@ -162,7 +162,7 @@ describe('env:delete', () => {
     });
 
   test
-    .stderr()
+    .stdout()
     .do(() => {
       sandbox.stub(Utils, 'resolveOrg' as any).returns(ORG_MOCK);
       sandbox.stub(SfProject, 'resolve' as any).returns(PROJECT_MOCK);
@@ -176,7 +176,7 @@ describe('env:delete', () => {
     .nock('https://api.heroku.com', (api) => api.get(`/apps/${COMPUTE_ENV_NAME}`).reply(200))
     .command(['env:delete', `--environment=${COMPUTE_ENV_ALIAS}`, `--confirm=${COMPUTE_ENV_ALIAS}`])
     .it('will use a compute environment if passed using the old flag (not --target-compute)', (ctx) => {
-      expect(vacuum(ctx.stderr).replace(/\n[›»]/gm, '')).to.contain(
+      expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
         vacuum(
           '--environment is deprecated and will be removed in a future release. Please use --target-compute going forward.'
         )

--- a/test/commands/env/delete.test.ts
+++ b/test/commands/env/delete.test.ts
@@ -37,7 +37,7 @@ const ORG_MOCK = {
   getOrgId: () => 'fakeid',
 };
 
-describe('env:delete', () => {
+describe('sf env delete', () => {
   const sandbox = sinon.createSandbox();
 
   test

--- a/test/commands/env/log.test.ts
+++ b/test/commands/env/log.test.ts
@@ -47,7 +47,7 @@ describe('logs', () => {
     });
 
   test
-    .stderr()
+    .stdout()
     .nock(logSessionURLBase, {}, (api) =>
       api.get(logSessionURLAddress).reply(200, (_uri: any, _requestBody: any) => {
         return fs.createReadStream('test/helpers/logoutput.txt');
@@ -56,7 +56,7 @@ describe('logs', () => {
     .nock('https://api.heroku.com', (api) => api.post(`/apps/${appName}/log-sessions`).reply(200, fakeResponseData))
     .command(['env:log', `--environment=${appName}`])
     .it('will use a compute environment if passed using the old flag (not --target-compute)', (ctx) => {
-      expect(vacuum(ctx.stderr).replace(/\n[›»]/gm, '')).to.contain(
+      expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
         vacuum(
           '--environment is deprecated and will be removed in a future release. Please use --target-compute going forward.'
         )

--- a/test/commands/env/log.test.ts
+++ b/test/commands/env/log.test.ts
@@ -9,7 +9,7 @@ import { expect, test } from '@oclif/test';
 import vacuum from '../../helpers/vacuum';
 const fs = require('fs');
 
-describe('logs', () => {
+describe('sf env logs', () => {
   const logSessionURLAddress = '/stream/5634e5b9-f9d4-48de-8c8c-4e368e5d40ff?srv=example';
   const logSessionURLBase = 'https://va.logs.heroku.com';
   const appName = 'foo-app-bar';

--- a/test/commands/env/log/tail.test.ts
+++ b/test/commands/env/log/tail.test.ts
@@ -33,7 +33,7 @@ describe('logs', () => {
     });
 
   test
-    .stderr()
+    .stdout()
     .nock(logSessionURLBase, {}, (api) =>
       api.get(logSessionURLAddress).reply(200, (_uri: any, _requestBody: any) => {
         return fs.createReadStream('test/helpers/logoutput.txt');
@@ -42,7 +42,7 @@ describe('logs', () => {
     .nock('https://api.heroku.com', (api) => api.post(`/apps/${appName}/log-sessions`).reply(200, fakeResponseData))
     .command(['env:log:tail', `--environment=${appName}`])
     .it('will use a compute environment if passed using the old flag (not --target-compute)', (ctx) => {
-      expect(vacuum(ctx.stderr).replace(/\n[›»]/gm, '')).to.contain(
+      expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
         vacuum(
           '--environment is deprecated and will be removed in a future release. Please use --target-compute going forward.'
         )

--- a/test/commands/env/log/tail.test.ts
+++ b/test/commands/env/log/tail.test.ts
@@ -9,7 +9,7 @@ import { expect, test } from '@oclif/test';
 import vacuum from '../../../helpers/vacuum';
 const fs = require('fs');
 
-describe('logs', () => {
+describe('sf env logs tail', () => {
   const logSessionURLAddress = '/stream/5634e5b9-f9d4-48de-8c8c-4e368e5d40ff?srv=example';
   const logSessionURLBase = 'https://va.logs.heroku.com';
   const appName = 'foo-app-bar';

--- a/test/commands/env/logdrain/add.test.ts
+++ b/test/commands/env/logdrain/add.test.ts
@@ -39,12 +39,12 @@ describe('sf env logdrain add', () => {
     });
 
   test
-    .stderr()
+    .stdout()
     .nock('https://api.heroku.com', (api) => api.post(`/apps/${APP_NAME}/log-drains`).reply(200, LOG_DRAIN))
     .command(['env:logdrain:add', '--environment', APP_NAME, '-l', LOG_DRAIN.url])
     .retries(3)
     .it('will use a compute environment if passed using the old flag (not --target-compute)', (ctx) => {
-      expect(vacuum(ctx.stderr).replace(/\n[›»]/gm, '')).to.contain(
+      expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
         vacuum(
           '--environment is deprecated and will be removed in a future release. Please use --target-compute going forward.'
         )
@@ -52,12 +52,12 @@ describe('sf env logdrain add', () => {
     });
 
   test
-    .stderr()
+    .stdout()
     .nock('https://api.heroku.com', (api) => api.post(`/apps/${APP_NAME}/log-drains`).reply(200, LOG_DRAIN))
     .command(['env:logdrain:add', '--target-compute', APP_NAME, '-u', LOG_DRAIN.url])
     .retries(3)
     .it('will use url if passed using the old flag (not --drain-url)', (ctx) => {
-      expect(vacuum(ctx.stderr).replace(/\n[›»]/gm, '')).to.contain(
+      expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
         vacuum('--url is deprecated and will be removed in a future release. Please use --drain-url going forward.')
       );
     });
@@ -65,7 +65,7 @@ describe('sf env logdrain add', () => {
   test
     .stdout()
     .nock('https://api.heroku.com', (api) => api.post(`/apps/${APP_NAME}/log-drains`).reply(200, LOG_DRAIN))
-    .command(['env:logdrain:add', '--target-compute', APP_NAME, '-u', LOG_DRAIN.url, '--json'])
+    .command(['env:logdrain:add', '--target-compute', APP_NAME, '-l', LOG_DRAIN.url, '--json'])
     .retries(3)
     .it('will show json output', (ctx) => {
       expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
@@ -86,7 +86,7 @@ describe('sf env logdrain add', () => {
     })
     .it('will show json output error with incorrect compute environment', (ctx) => {
       expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
-        vacuum('{\n"status": 1,\n"message": "Could not find environment <invalid-environment>"')
+        vacuum('{\n"status": 1,\n"message": "Could not find environment invalid-environment"')
       );
     });
 
@@ -99,7 +99,7 @@ describe('sf env logdrain add', () => {
     })
     .it('will show json output error with incorrect drain-url', (ctx) => {
       expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
-        vacuum('{\n"status": 1,\n"message": "URL is invalid <invalid-url>",\n"name": "Error"')
+        vacuum('{\n"status": 1,\n"message": "URL is invalid invalid-url",\n"name": "Error"')
       );
     });
 
@@ -115,7 +115,7 @@ describe('sf env logdrain add', () => {
     .it('will show json output error with drain-url already used', (ctx) => {
       expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
         vacuum(
-          '{\n"status": 1,\n"message": "Logdrain URL is already added <https://logs-r-us.com/1>",\n"name": "Error",'
+          '{\n"status": 1,\n"message": "Logdrain URL is already added https://logs-r-us.com/1",\n"name": "Error",\n"'
         )
       );
     });

--- a/test/commands/env/logdrain/list.test.ts
+++ b/test/commands/env/logdrain/list.test.ts
@@ -72,4 +72,17 @@ describe('sf env logdrain list', () => {
     .it('shows log drains in JSON when --json is passed', (ctx) => {
       expect(JSON.parse(ctx.stdout)).to.deep.equal(SUCCESS_OUTPUT);
     });
+
+  test
+    .stdout()
+    .stderr()
+    .nock('https://api.heroku.com', (api) => api.get(`/apps/${APP_NAME}/log-drains`).reply(200, []))
+    .command(['env:logdrain:list', '-e', APP_NAME, '--json'])
+    .it('warns when log drains is empty when --json is passed', (ctx) => {
+      expect(JSON.parse(ctx.stdout)).to.deep.equal({
+        status: 0,
+        result: [],
+        warnings: ['No logdrain found for environment <my-app>'],
+      });
+    });
 });

--- a/test/commands/env/logdrain/list.test.ts
+++ b/test/commands/env/logdrain/list.test.ts
@@ -48,16 +48,16 @@ describe('sf env logdrain list', () => {
     .stderr()
     .nock('https://api.heroku.com', (api) => api.get(`/apps/${APP_NAME}/log-drains`).reply(200, []))
     .command(['env:logdrain:list', '-e', APP_NAME])
-    .it('shows a list of log drains', (ctx) => {
-      expect(ctx.stdout).to.contain(`No log drains found for environment ${APP_NAME}.`);
+    .it('warns on an empty list of log drains', (ctx) => {
+      expect(ctx.stdout).to.contain(`Warning: No log-drains found for environment ${APP_NAME}`);
     });
 
   test
-    .stderr()
+    .stdout()
     .nock('https://api.heroku.com', (api) => api.get(`/apps/${APP_NAME}/log-drains`).reply(200, LOG_DRAINS))
     .command(['env:logdrain:list', '--environment', APP_NAME])
     .it('will use a compute environment if passed using the old flag (not --target-compute)', (ctx) => {
-      expect(vacuum(ctx.stderr).replace(/\n[›»]/gm, '')).to.contain(
+      expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
         vacuum(
           '--environment is deprecated and will be removed in a future release. Please use --target-compute going forward.'
         )
@@ -82,7 +82,7 @@ describe('sf env logdrain list', () => {
       expect(JSON.parse(ctx.stdout)).to.deep.equal({
         status: 0,
         result: [],
-        warnings: ['No logdrain found for environment <my-app>'],
+        warnings: ['No log-drains found for environment my-app'],
       });
     });
 });

--- a/test/commands/env/logdrain/remove.test.ts
+++ b/test/commands/env/logdrain/remove.test.ts
@@ -53,7 +53,7 @@ describe('sf env logdrain remove', () => {
     .command(['env:logdrain:remove', '--target-compute', APP_NAME, '-u', LOG_DRAIN.url, '--json'])
     .it('will show json output', (ctx) => {
       expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
-        vacuum('{\n"status": 0,\n"result": null,\n"warnings": []\n}')
+        vacuum('{\n"status": 0,\n"result": [],\n"warnings": []\n}')
       );
     });
 

--- a/test/commands/env/logdrain/remove.test.ts
+++ b/test/commands/env/logdrain/remove.test.ts
@@ -54,7 +54,7 @@ describe('sf env logdrain remove', () => {
     .command(['env:logdrain:remove', '--target-compute', APP_NAME, '-l', LOG_DRAIN.url, '--json'])
     .it('will show json output', (ctx) => {
       expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
-        vacuum('{\n"status": 0,\n"result": [],\n"warnings": []\n}')
+        vacuum('{\n"status": 0,\n"result": "Removed drain-url",\n"warnings": []\n}')
       );
     });
 

--- a/test/commands/env/logdrain/remove.test.ts
+++ b/test/commands/env/logdrain/remove.test.ts
@@ -23,6 +23,7 @@ describe('sf env logdrain remove', () => {
   test
     .stdout()
     .stderr()
+    .retries(2)
     .nock('https://api.heroku.com', (api) =>
       api.delete(`/apps/${APP_NAME}/log-drains/${encodeURIComponent(LOG_DRAIN.url)}`).reply(200, LOG_DRAIN)
     )
@@ -32,13 +33,13 @@ describe('sf env logdrain remove', () => {
     });
 
   test
-    .stderr()
+    .stdout()
     .nock('https://api.heroku.com', (api) =>
       api.delete(`/apps/${APP_NAME}/log-drains/${encodeURIComponent(LOG_DRAIN.url)}`).reply(200, LOG_DRAIN)
     )
     .command(['env:logdrain:remove', '--environment', APP_NAME, '-l', LOG_DRAIN.url])
     .it('will use a compute environment if passed using the old flag (not --target-compute)', (ctx) => {
-      expect(vacuum(ctx.stderr).replace(/\n[›»]/gm, '')).to.contain(
+      expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
         vacuum(
           '--environment is deprecated and will be removed in a future release. Please use --target-compute going forward.'
         )
@@ -50,7 +51,7 @@ describe('sf env logdrain remove', () => {
     .nock('https://api.heroku.com', (api) =>
       api.delete(`/apps/${APP_NAME}/log-drains/${encodeURIComponent(LOG_DRAIN.url)}`).reply(200, LOG_DRAIN)
     )
-    .command(['env:logdrain:remove', '--target-compute', APP_NAME, '-u', LOG_DRAIN.url, '--json'])
+    .command(['env:logdrain:remove', '--target-compute', APP_NAME, '-l', LOG_DRAIN.url, '--json'])
     .it('will show json output', (ctx) => {
       expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
         vacuum('{\n"status": 0,\n"result": [],\n"warnings": []\n}')
@@ -70,7 +71,7 @@ describe('sf env logdrain remove', () => {
     })
     .it('will show json output error with incorrect compute environment', (ctx) => {
       expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
-        vacuum('{\n"status": 1,\n"message": "Couldn\'t find that app <invalid-environment>",\n"name": "Error"')
+        vacuum('{\n"status": 1,\n"message": "Couldn\'t find that app invalid-environment",\n"name": "Error"')
       );
     });
 });

--- a/test/commands/env/var/get.test.ts
+++ b/test/commands/env/var/get.test.ts
@@ -24,15 +24,14 @@ describe('sf env:var:get', () => {
 
   test
     .stdout()
-    .stderr()
     .nock('https://api.heroku.com', (api) => api.get('/apps/my-environment/config-vars').reply(200, {}))
     .command(['env:var:get', 'foo', '--target-compute', 'my-environment'])
     .it('shows a message when the config var is not defined', (ctx) => {
-      expect(ctx.stderr).to.include('Warning: No config var named foo found for environment my-environment');
+      expect(ctx.stdout).to.include('Warning: No config var named foo found for environment my-environment');
     });
 
   test
-    .stderr()
+    .stdout()
     .nock('https://api.heroku.com', (api) =>
       api.get('/apps/my-environment/config-vars').reply(200, {
         foo: 'bar',
@@ -40,7 +39,7 @@ describe('sf env:var:get', () => {
     )
     .command(['env:var:get', 'foo', '--environment', 'my-environment'])
     .it('will use a compute environment if passed using the old flag (not --target-compute)', (ctx) => {
-      expect(vacuum(ctx.stderr).replace(/\n[›»]/gm, '')).to.contain(
+      expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
         vacuum(
           '--environment is deprecated and will be removed in a future release. Please use --target-compute going forward.'
         )
@@ -54,7 +53,7 @@ describe('sf env:var:get', () => {
         foo: 'bar',
       })
     )
-    .command(['env:var:get', 'foo', '--environment', 'my-environment', '--json'])
+    .command(['env:var:get', 'foo', '--target-compute', 'my-environment', '--json'])
     .it('will show json output', (ctx) => {
       expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
         vacuum('{\n"status": 0,\n"result": "bar",\n"warnings": []\n}')
@@ -68,11 +67,11 @@ describe('sf env:var:get', () => {
         foo: 'bar',
       })
     )
-    .command(['env:var:get', 'doo', '--environment', 'my-environment', '--json'])
+    .command(['env:var:get', 'baz', '--target-compute', 'my-environment', '--json'])
     .it('will show json warning output with incorrect config var', (ctx) => {
       expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
         vacuum(
-          '{\n"status": 0,\n"result": [],\n"warnings": [\n"No config var named doo found for environment <my-environment>"\n]\n}'
+          '{\n"status": 0,\n"result": [],\n"warnings": [\n"No config var named baz found for environment my-environment"\n]\n}'
         )
       );
     });

--- a/test/commands/env/var/get.test.ts
+++ b/test/commands/env/var/get.test.ts
@@ -72,7 +72,7 @@ describe('sf env:var:get', () => {
     .it('will show json warning output with incorrect config var', (ctx) => {
       expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
         vacuum(
-          '{\n"status": 0,\n"result": null,\n"warnings": [\n"No config var named doo found for environment <my-environment>"\n]\n}'
+          '{\n"status": 0,\n"result": [],\n"warnings": [\n"No config var named doo found for environment <my-environment>"\n]\n}'
         )
       );
     });

--- a/test/commands/env/var/get.test.ts
+++ b/test/commands/env/var/get.test.ts
@@ -7,7 +7,7 @@
 import { expect, test } from '@oclif/test';
 import vacuum from '../../../helpers/vacuum';
 
-describe('sf env:var:get', () => {
+describe('sf env var get', () => {
   test
     .stdout()
     .stderr()

--- a/test/commands/env/var/list.test.ts
+++ b/test/commands/env/var/list.test.ts
@@ -8,7 +8,7 @@ import { expect, test } from '@oclif/test';
 
 import vacuum from '../../../helpers/vacuum';
 
-describe('sf env:var:list', () => {
+describe('sf env var list', () => {
   test
     .stdout()
     .stderr()

--- a/test/commands/env/var/list.test.ts
+++ b/test/commands/env/var/list.test.ts
@@ -36,7 +36,7 @@ describe('sf env:var:list', () => {
     .nock('https://api.heroku.com', (api) => api.get('/apps/my-environment/config-vars').reply(200, {}))
     .command(['env:var:list', '--target-compute', 'my-environment'])
     .it('shows a message when there are no config vars', (ctx) => {
-      expect(ctx.stderr).to.include('Warning: No config vars found for environment my-environment');
+      expect(ctx.stdout).to.include('Warning: No config vars found for environment my-environment');
     });
   test
     .stdout()
@@ -60,7 +60,7 @@ describe('sf env:var:list', () => {
     });
 
   test
-    .stderr()
+    .stdout()
     .nock('https://api.heroku.com', (api) =>
       api.get('/apps/my-environment/config-vars').reply(200, {
         foo: 'bar',
@@ -69,7 +69,7 @@ describe('sf env:var:list', () => {
     )
     .command(['env:var:list', '--environment', 'my-environment'])
     .it('will use a compute environment if passed using the old flag (not --target-compute)', (ctx) => {
-      expect(vacuum(ctx.stderr).replace(/\n[›»]/gm, '')).to.contain(
+      expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
         vacuum(
           '--environment is deprecated and will be removed in a future release. Please use --target-compute going forward.'
         )

--- a/test/commands/env/var/set.test.ts
+++ b/test/commands/env/var/set.test.ts
@@ -61,9 +61,9 @@ describe('sf env:var:set', () => {
     });
 
   test
-    .stderr()
+    .stdout()
     // Adding retries here because there is some kind of race condition that causes fancy-test to not
-    // fully capture the value of stderr when running in CI (╯°□°)╯︵ ┻━┻
+    // fully capture the value of stdout when running in CI (╯°□°)╯︵ ┻━┻
     .retries(2)
     .nock('https://api.heroku.com', (api) =>
       api
@@ -74,7 +74,7 @@ describe('sf env:var:set', () => {
     )
     .command(['env:var:set', 'foo=bar', '--environment', 'my-environment'])
     .it('will use a compute environment if passed using the old flag (not --target-compute)', (ctx) => {
-      expect(vacuum(ctx.stderr).replace(/\n[›»]/gm, '')).to.contain(
+      expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
         vacuum(
           '--environment is deprecated and will be removed in a future release. Please use --target-compute going forward.'
         )

--- a/test/commands/env/var/set.test.ts
+++ b/test/commands/env/var/set.test.ts
@@ -7,7 +7,7 @@
 import { expect, test } from '@oclif/test';
 import vacuum from '../../../helpers/vacuum';
 
-describe('sf env:var:set', () => {
+describe('sf env var set', () => {
   test
     .stdout()
     .stderr()
@@ -121,7 +121,7 @@ describe('sf env:var:set', () => {
     .command(['env:var:set', 'foo=bar', '--target-compute', 'my-environment', '--json'])
     .it('will show json output', (ctx) => {
       expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
-        vacuum('{\n"status": 0,\n"result": [],\n"warnings": []\n}')
+        vacuum('{\n"status": 0,\n"result": "Set env var",\n"warnings": []\n}')
       );
     });
 });

--- a/test/commands/env/var/set.test.ts
+++ b/test/commands/env/var/set.test.ts
@@ -121,7 +121,7 @@ describe('sf env:var:set', () => {
     .command(['env:var:set', 'foo=bar', '--target-compute', 'my-environment', '--json'])
     .it('will show json output', (ctx) => {
       expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
-        vacuum('{\n"status": 0,\n"result": null,\n"warnings": []\n}')
+        vacuum('{\n"status": 0,\n"result": [],\n"warnings": []\n}')
       );
     });
 });

--- a/test/commands/env/var/unset.test.ts
+++ b/test/commands/env/var/unset.test.ts
@@ -8,10 +8,10 @@ import { CLIError } from '@oclif/core/lib/errors';
 import { expect, test } from '@oclif/test';
 import vacuum from '../../../helpers/vacuum';
 
-describe('sf env:var:unset', () => {
+describe('sf env var unset', () => {
   const jsonSuccess = {
     status: 0,
-    result: [],
+    result: 'Unset env var',
     warnings: [],
   };
   const jsonAppError = {

--- a/test/commands/env/var/unset.test.ts
+++ b/test/commands/env/var/unset.test.ts
@@ -11,7 +11,7 @@ import vacuum from '../../../helpers/vacuum';
 describe('sf env:var:unset', () => {
   const jsonSuccess = {
     status: 0,
-    result: null,
+    result: [],
     warnings: [],
   };
   const jsonAppError = {

--- a/test/commands/env/var/unset.test.ts
+++ b/test/commands/env/var/unset.test.ts
@@ -17,7 +17,7 @@ describe('sf env:var:unset', () => {
   const jsonAppError = {
     status: 1,
     name: 'Error',
-    message: "Couldn't find that app <my-environment>",
+    message: "Couldn't find that app my-environment",
     warnings: [],
   };
 
@@ -103,7 +103,7 @@ describe('sf env:var:unset', () => {
     });
 
   test
-    .stderr()
+    .stdout()
     .nock('https://api.heroku.com', (api) =>
       api
         .patch('/apps/my-environment/config-vars', {
@@ -118,7 +118,7 @@ describe('sf env:var:unset', () => {
     )
     .command(['env:var:unset', 'foo', '--environment', 'my-environment'])
     .it('will use a compute environment if passed using the old flag (not --target-compute)', (ctx) => {
-      expect(vacuum(ctx.stderr).replace(/\n[›»]/gm, '')).to.contain(
+      expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
         vacuum(
           '--environment is deprecated and will be removed in a future release. Please use --target-compute going forward.'
         )
@@ -137,7 +137,7 @@ describe('sf env:var:unset', () => {
     .stdout()
     .command(['env:var:unset', 'foo', '--environment', 'my-environment2'])
     .catch((error) => {
-      expect(error.message).to.contain("Couldn't find that app <my-environment2>");
+      expect(error.message).to.contain("Couldn't find that app my-environment2");
     })
     .it('errors with incorrect compute environment');
 });

--- a/test/commands/env/var/unset.test.ts
+++ b/test/commands/env/var/unset.test.ts
@@ -24,6 +24,9 @@ describe('sf env:var:unset', () => {
   test
     .stdout()
     .stderr()
+    // Adding retries here because there is some kind of race condition that causes fancy-test to not
+    // fully capture the value of stderr when running in CI (╯°□°)╯︵ ┻━┻
+    .retries(2)
     .nock('https://api.heroku.com', (api) =>
       api
         .patch('/apps/my-environment/config-vars', {

--- a/test/commands/generate/function.test.ts
+++ b/test/commands/generate/function.test.ts
@@ -39,7 +39,7 @@ describe('sf generate:function', () => {
     });
 
   test
-    .stderr()
+    .stdout()
     .do(() => {
       generateFunctionStub.returns({
         name,
@@ -50,7 +50,7 @@ describe('sf generate:function', () => {
     })
     .command(['generate:function', `--name=${name}`, '--language=javascript'])
     .it('will use name if passed using the old flag (not --function-name)', (ctx) => {
-      expect(vacuum(ctx.stderr).replace(/\n[›»]/gm, '')).to.contain(
+      expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
         vacuum(
           '--name is deprecated and will be removed in a future release. Please use --function-name going forward.'
         )

--- a/test/commands/generate/function.test.ts
+++ b/test/commands/generate/function.test.ts
@@ -9,7 +9,7 @@ import * as sinon from 'sinon';
 import * as library from '@hk/functions-core';
 import vacuum from '../../helpers/vacuum';
 
-describe('sf generate:function', () => {
+describe('sf generate function', () => {
   const sandbox: sinon.SinonSandbox = sinon.createSandbox();
   let generateFunctionStub: sinon.SinonStub;
   const path = 'some/functions/path';

--- a/test/commands/login/functions/jwt.test.ts
+++ b/test/commands/login/functions/jwt.test.ts
@@ -161,7 +161,7 @@ describe('sf login functions jwt', () => {
       '--instanceurl=foo.com',
     ])
     .it('will use an instance URL if passed using the old flag (no dash)', (ctx) => {
-      expect(vacuum(ctx.stderr).replace(/\n[›»]/gm, '')).to.include(
+      expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.include(
         vacuum(
           '--instanceurl is deprecated and will be removed in a future release. Please use --instance-url going forward.'
         )

--- a/test/commands/logout/functions.test.ts
+++ b/test/commands/logout/functions.test.ts
@@ -34,7 +34,7 @@ describe('sf logout functions', () => {
     .command(['logout:functions', '--json'])
     .it('will show json output', (ctx) => {
       expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
-        vacuum('{\n"status": 0,\n"result": [],\n"warnings": []\n}')
+        vacuum('{\n"status": 0,\n"result": "Logged out",\n"warnings": []\n}')
       );
     });
 });

--- a/test/commands/logout/functions.test.ts
+++ b/test/commands/logout/functions.test.ts
@@ -31,7 +31,7 @@ describe('sf logout functions', () => {
   test
     .stdout()
     .stderr()
-    .command(['logout:functions', '-j'])
+    .command(['logout:functions', '--json'])
     .it('will show json output', (ctx) => {
       expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
         vacuum('{\n"status": 0,\n"result": [],\n"warnings": []\n}')

--- a/test/commands/project/deploy/functions.test.ts
+++ b/test/commands/project/deploy/functions.test.ts
@@ -88,20 +88,18 @@ const ORG_MOCK_WITH_DELETED_FUNCTION = {
 
 const jsonSuccess = {
   status: 0,
-  result: {
-    results: [
-      {
-        created: true,
-        fullName: 'sweet_project-fn1',
-        success: true,
-      },
-      {
-        created: true,
-        fullName: 'sweet_project-fn2',
-        success: true,
-      },
-    ],
-  },
+  result: [
+    {
+      created: true,
+      fullName: 'sweet_project-fn1',
+      success: true,
+    },
+    {
+      created: true,
+      fullName: 'sweet_project-fn2',
+      success: true,
+    },
+  ],
   warnings: [],
 };
 

--- a/test/commands/run/function.test.ts
+++ b/test/commands/run/function.test.ts
@@ -14,7 +14,7 @@ import * as sinon from 'sinon';
 import * as library from '@hk/functions-core';
 import vacuum from '../../helpers/vacuum';
 
-describe('run:function', () => {
+describe('sf run function', () => {
   const $$ = testSetup();
   const targetUrl = 'http://localhost';
   const userpayload = '{"id":654321,"field1":"somefield"}';

--- a/test/commands/run/function.test.ts
+++ b/test/commands/run/function.test.ts
@@ -57,7 +57,7 @@ describe('run:function', () => {
     test
       .stdout()
       .stderr()
-      .command(['run:function', '-l', targetUrl, '-p', userpayload, '-j'])
+      .command(['run:function', '-l', targetUrl, '-p', userpayload, '--json'])
       .it('will show json output', (ctx) => {
         expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
           vacuum('{\n"status": 0,\n"result": "Something happened!",\n"warnings": []\n}')
@@ -87,7 +87,7 @@ describe('run:function', () => {
         '--structured',
         '-o',
         OrgConfigProperties.TARGET_ORG,
-        '-j',
+        '--json',
       ])
       .it('Should call the library with all arguments', async () => {
         sinon.assert.calledWith(

--- a/test/commands/run/function.test.ts
+++ b/test/commands/run/function.test.ts
@@ -56,7 +56,7 @@ describe('run:function', () => {
     });
     test
       .stdout()
-      .stderr()
+      .retries(2)
       .command(['run:function', '-l', targetUrl, '-p', userpayload, '--json'])
       .it('will show json output', (ctx) => {
         expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
@@ -111,10 +111,10 @@ describe('run:function', () => {
       });
 
     test
-      .stderr()
+      .stdout()
       .command(['run:function', '--url', targetUrl, '-p', userpayload])
       .it('will use url if passed using the old flag (not --function-url)', (ctx) => {
-        expect(vacuum(ctx.stderr).replace(/\n[›»]/gm, '')).to.contain(
+        expect(vacuum(ctx.stdout).replace(/\n[›»]/gm, '')).to.contain(
           vacuum(
             '--url is deprecated and will be removed in a future release. Please use --function-url going forward.'
           )
@@ -183,11 +183,10 @@ describe('run:function', () => {
 
     test
       .stdout()
-      .stderr()
       .command(['run:function', '-l', targetUrl, '-p {"id":12345}'])
       .it('should output the response from the server', (ctx) => {
         expect(ctx.stdout).to.contain('Something happened!');
-        expect(ctx.stderr).to.contain('Warning: No -o connected org or target-org found');
+        expect(ctx.stdout).to.contain('Warning: No -o connected org or target-org found');
       });
   });
 });

--- a/test/commands/run/function/start.test.ts
+++ b/test/commands/run/function/start.test.ts
@@ -11,7 +11,7 @@ import { expect, test } from '@oclif/test';
 import * as sinon from 'sinon';
 import { LocalRun, LocalRunProcess } from '@hk/functions-core';
 
-describe('run:function:start', () => {
+describe('sdf run function start', () => {
   let sandbox: sinon.SinonSandbox;
   let localRunExecStub: sinon.SinonStub;
   let childProcess: ChildProcess;

--- a/test/commands/run/function/start/container.test.ts
+++ b/test/commands/run/function/start/container.test.ts
@@ -11,7 +11,7 @@ import * as sinon from 'sinon';
 import * as library from '@hk/functions-core';
 import { Benny } from '@hk/functions-core';
 
-describe('function:start:container', () => {
+describe('sd function start container', () => {
   let sandbox: sinon.SinonSandbox;
   let bennyRunStub: sinon.SinonStub;
   let bennyBuildStub: sinon.SinonStub;

--- a/test/commands/run/function/start/local.test.ts
+++ b/test/commands/run/function/start/local.test.ts
@@ -14,7 +14,7 @@ import { SinonStub, SinonStubbedInstance } from 'sinon';
 import { LangRunnerOpts } from '@hk/functions-core/dist/lang-runner';
 import Local from '../../../../../src/commands/run/function/start/local';
 
-describe('run:function:start:local', () => {
+describe('sf run function start local', () => {
   const fixturesPath = path.resolve(__dirname, '../../../../fixtures');
   const jsPath = path.resolve(fixturesPath, 'javascripttemplate');
   const javaPath = path.resolve(fixturesPath, 'javatemplate');

--- a/test/commands/whoami/functions.test.ts
+++ b/test/commands/whoami/functions.test.ts
@@ -6,7 +6,7 @@
  */
 import { expect, test } from '@oclif/test';
 
-describe('sf whoami:functions', () => {
+describe('sf whoami functions', () => {
   test
     .stdout()
     .stderr()


### PR DESCRIPTION
### What does this PR do?
Remove -j from json flag and moves --json into global flags in help

Use this.warn to add warnings to json object

Return result from run for json handler & schema check

### What issues does this PR fix or reference?
@W-00000000@
