### PR TITLE
feat: add support for generating and starting Python functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,11 +482,11 @@ Create a Salesforce Function with basic scaffolding specific to a given language
 
 ```
 USAGE
-  $ sf generate function -l javascript|typescript|java [-n <value> | ]
+  $ sf generate function -l java|javascript|python|typescript [-n <value> | ]
 
 FLAGS
-  -l, --language=(javascript|typescript|java)  (required) Language. Can be one of: javascript, typescript, java.
-  -n, --function-name=<value>                  Function name. Must start with a capital letter.
+  -l, --language=(java|javascript|python|typescript)  (required) The language in which the function is written.
+  -n, --function-name=<value>                         Function name. Must start with a capital letter.
 
 DESCRIPTION
   Create a Salesforce Function with basic scaffolding specific to a given language.
@@ -605,13 +605,13 @@ Build and run a Salesforce Function.
 
 ```
 USAGE
-  $ sf run function start [-b <value>] [-l javascript|typescript|java|auto] [-p <value>] [-v]
+  $ sf run function start [-b <value>] [-l auto|java|javascript|python|typescript] [-p <value>] [-v]
 
 FLAGS
-  -b, --debug-port=<value>                          [default: 9229] Port for remote debugging.
-  -l, --language=(javascript|typescript|java|auto)  [default: auto] The language that the function runs in.
-  -p, --port=<value>                                [default: 8080] Port for running the function.
-  -v, --verbose                                     Output additional logs.
+  -b, --debug-port=<value>                                 [default: 9229] Port for remote debugging.
+  -l, --language=(auto|java|javascript|python|typescript)  [default: auto] The language that the function runs in.
+  -p, --port=<value>                                       [default: 8080] Port for running the function.
+  -v, --verbose                                            Output additional logs.
 
 DESCRIPTION
   Build and run a Salesforce Function.
@@ -679,12 +679,13 @@ Build and run a Salesforce Function locally.
 
 ```
 USAGE
-  $ sf run function start local [-p <value>] [-b <value>] [-l javascript|typescript|java|auto]
+  $ sf run function start local [-p <value>] [-b <value>] [-l auto|java|javascript|python|typescript]
 
 FLAGS
-  -b, --debug-port=<value>                          [default: 9229] Port to use for debbugging the function.
-  -l, --language=(javascript|typescript|java|auto)  [default: auto] The language that the function runs in.
-  -p, --port=<value>                                [default: 8080] Port to bind the invoker to.
+  -b, --debug-port=<value>                                 [default: 9229] Port to use for debbugging the function.
+  -l, --language=(auto|java|javascript|python|typescript)  [default: auto] The language in which the function is
+                                                           written.
+  -p, --port=<value>                                       [default: 8080] Port to bind the invoker to.
 
 DESCRIPTION
   Build and run a Salesforce Function locally.

--- a/README.md
+++ b/README.md
@@ -482,11 +482,11 @@ Create a Salesforce Function with basic scaffolding specific to a given language
 
 ```
 USAGE
-  $ sf generate function -l java|javascript|python|typescript [-n <value> | ]
+  $ sf generate function -l java|javascript|typescript [-n <value> | ]
 
 FLAGS
-  -l, --language=(java|javascript|python|typescript)  (required) The language in which the function is written.
-  -n, --function-name=<value>                         Function name. Must start with a capital letter.
+  -l, --language=(java|javascript|typescript)  (required) The language in which the function is written.
+  -n, --function-name=<value>                  Function name. Must start with a capital letter.
 
 DESCRIPTION
   Create a Salesforce Function with basic scaffolding specific to a given language.
@@ -605,13 +605,13 @@ Build and run a Salesforce Function.
 
 ```
 USAGE
-  $ sf run function start [-b <value>] [-l auto|java|javascript|python|typescript] [-p <value>] [-v]
+  $ sf run function start [-b <value>] [-l auto|java|javascript|typescript] [-p <value>] [-v]
 
 FLAGS
-  -b, --debug-port=<value>                                 [default: 9229] Port for remote debugging.
-  -l, --language=(auto|java|javascript|python|typescript)  [default: auto] The language that the function runs in.
-  -p, --port=<value>                                       [default: 8080] Port for running the function.
-  -v, --verbose                                            Output additional logs.
+  -b, --debug-port=<value>                          [default: 9229] Port for remote debugging.
+  -l, --language=(auto|java|javascript|typescript)  [default: auto] The language that the function runs in.
+  -p, --port=<value>                                [default: 8080] Port for running the function.
+  -v, --verbose                                     Output additional logs.
 
 DESCRIPTION
   Build and run a Salesforce Function.
@@ -679,13 +679,12 @@ Build and run a Salesforce Function locally.
 
 ```
 USAGE
-  $ sf run function start local [-p <value>] [-b <value>] [-l auto|java|javascript|python|typescript]
+  $ sf run function start local [-p <value>] [-b <value>] [-l auto|java|javascript|typescript]
 
 FLAGS
-  -b, --debug-port=<value>                                 [default: 9229] Port to use for debbugging the function.
-  -l, --language=(auto|java|javascript|python|typescript)  [default: auto] The language in which the function is
-                                                           written.
-  -p, --port=<value>                                       [default: 8080] Port to bind the invoker to.
+  -b, --debug-port=<value>                          [default: 9229] Port to use for debugging the function.
+  -l, --language=(auto|java|javascript|typescript)  [default: auto] The language in which the function is written.
+  -p, --port=<value>                                [default: 8080] Port to bind the invoker to.
 
 DESCRIPTION
   Build and run a Salesforce Function locally.

--- a/messages/generate.function.md
+++ b/messages/generate.function.md
@@ -18,7 +18,7 @@ Function name. Must start with a capital letter.
 
 # flags.language.summary
 
-Language. Can be one of: javascript, typescript, java.
+The language in which the function is written.
 
 # flags.name.deprecation
 

--- a/messages/run.function.start.local.md
+++ b/messages/run.function.start.local.md
@@ -26,7 +26,7 @@ Port to bind the invoker to.
 
 # flags.debug-port.summary
 
-Port to use for debbugging the function.
+Port to use for debugging the function.
 
 # flags.language.summary
 

--- a/messages/run.function.start.local.md
+++ b/messages/run.function.start.local.md
@@ -30,4 +30,4 @@ Port to use for debbugging the function.
 
 # flags.language.summary
 
-The language that the function runs in.
+The language in which the function is written.

--- a/src/commands/generate/function.ts
+++ b/src/commands/generate/function.ts
@@ -13,6 +13,16 @@ import Command from '../../lib/base';
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-functions', 'generate.function');
 
+// TODO: Make sf-functions-core export the list of language options it supports
+// for the generate function feature, and use that instead of hardcoding here.
+// See W-12120598.
+const languageOptions = [
+  'java',
+  'javascript',
+  ...('PYTHON_FUNCTIONS_ALPHA' in process.env ? ['python'] : []),
+  'typescript',
+];
+
 /**
  * Based on given language, create function project with specific scaffolding.
  */
@@ -38,7 +48,7 @@ export default class GenerateFunction extends Command {
       hidden: true,
     }),
     language: Flags.enum({
-      options: ['java', 'javascript', 'python', 'typescript'],
+      options: languageOptions,
       description: messages.getMessage('flags.language.summary'),
       char: 'l',
       required: true,

--- a/src/commands/generate/function.ts
+++ b/src/commands/generate/function.ts
@@ -67,6 +67,10 @@ export default class GenerateFunction extends Command {
       );
     }
 
+    if (flags.language === 'python') {
+      this.warn('Python support for Salesforce Functions is experimental.');
+    }
+
     if (flags.name) {
       this.warn(messages.getMessage('flags.name.deprecation'));
     }

--- a/src/commands/generate/function.ts
+++ b/src/commands/generate/function.ts
@@ -38,7 +38,7 @@ export default class GenerateFunction extends Command {
       hidden: true,
     }),
     language: Flags.enum({
-      options: ['javascript', 'typescript', 'java'],
+      options: ['java', 'javascript', 'python', 'typescript'],
       description: messages.getMessage('flags.language.summary'),
       char: 'l',
       required: true,

--- a/src/commands/run/function/start.ts
+++ b/src/commands/run/function/start.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 import { Messages } from '@salesforce/core';
 import { Flags } from '@oclif/core';
 
-import Local from './start/local';
+import Local, { languageOptions } from './start/local';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-functions', 'run.function.start');
@@ -45,7 +45,7 @@ export default class Start extends Local {
     }),
     language: Flags.enum({
       description: messages.getMessage('flags.language.summary'),
-      options: ['auto', 'java', 'javascript', 'python', 'typescript'],
+      options: languageOptions,
       char: 'l',
       default: 'auto',
     }),

--- a/src/commands/run/function/start.ts
+++ b/src/commands/run/function/start.ts
@@ -45,7 +45,7 @@ export default class Start extends Local {
     }),
     language: Flags.enum({
       description: messages.getMessage('flags.language.summary'),
-      options: ['javascript', 'typescript', 'java', 'auto'],
+      options: ['auto', 'java', 'javascript', 'python', 'typescript'],
       char: 'l',
       default: 'auto',
     }),

--- a/src/commands/run/function/start/local.ts
+++ b/src/commands/run/function/start/local.ts
@@ -35,7 +35,7 @@ export default class Local extends Command {
       default: 9229,
     }),
     language: Flags.enum({
-      options: ['javascript', 'typescript', 'java', 'auto'],
+      options: ['auto', 'java', 'javascript', 'python', 'typescript'],
       description: messages.getMessage('flags.language.summary'),
       char: 'l',
       default: 'auto',

--- a/src/commands/run/function/start/local.ts
+++ b/src/commands/run/function/start/local.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import * as path from 'path';
+import * as process from 'process';
 import { Command, Flags } from '@oclif/core';
 import { LocalRun } from '@hk/functions-core';
 import { Messages } from '@salesforce/core';
@@ -12,6 +13,17 @@ import { LangRunnerOpts } from '@hk/functions-core/dist/lang-runner';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-functions', 'run.function.start.local');
+
+// TODO: Make sf-functions-core export the list of language options it supports
+// for the local functions runners, and use that instead of hardcoding here.
+// See W-12120598.
+export const languageOptions = [
+  'auto',
+  'java',
+  'javascript',
+  ...('PYTHON_FUNCTIONS_ALPHA' in process.env ? ['python'] : []),
+  'typescript',
+];
 
 export default class Local extends Command {
   static description = messages.getMessage('summary');
@@ -35,7 +47,7 @@ export default class Local extends Command {
       default: 9229,
     }),
     language: Flags.enum({
-      options: ['auto', 'java', 'javascript', 'python', 'typescript'],
+      options: languageOptions,
       description: messages.getMessage('flags.language.summary'),
       char: 'l',
       default: 'auto',

--- a/test/commands/run/function/start/local.test.ts
+++ b/test/commands/run/function/start/local.test.ts
@@ -65,11 +65,33 @@ describe('sf run function start local', () => {
       });
   });
 
+  context('with -l java', () => {
+    test.command(['run:function:start:local', '-l', 'java']).it('should start the local runner in java mode', (ctx) => {
+      expect(localRunConstructor).to.have.been.calledWith('java', {
+        port: 8080,
+        debugPort: 9229,
+        path: defaultFunctionPath,
+      });
+    });
+  });
+
   context('with -l javascript', () => {
     test
       .command(['run:function:start:local', '-l', 'javascript'])
       .it('should start the local runner in javascript mode', (ctx) => {
         expect(localRunConstructor).to.have.been.calledWith('javascript', {
+          port: 8080,
+          debugPort: 9229,
+          path: defaultFunctionPath,
+        });
+      });
+  });
+
+  context('with -l python', () => {
+    test
+      .command(['run:function:start:local', '-l', 'python'])
+      .it('should start the local runner in python mode', (ctx) => {
+        expect(localRunConstructor).to.have.been.calledWith('python', {
           port: 8080,
           debugPort: 9229,
           path: defaultFunctionPath,
@@ -87,16 +109,6 @@ describe('sf run function start local', () => {
           path: defaultFunctionPath,
         });
       });
-  });
-
-  context('with -l java', () => {
-    test.command(['run:function:start:local', '-l', 'java']).it('should start the local runner in java mode', (ctx) => {
-      expect(localRunConstructor).to.have.been.calledWith('java', {
-        port: 8080,
-        debugPort: 9229,
-        path: defaultFunctionPath,
-      });
-    });
   });
 
   context('with --path', () => {

--- a/test/commands/run/function/start/local.test.ts
+++ b/test/commands/run/function/start/local.test.ts
@@ -88,7 +88,18 @@ describe('sf run function start local', () => {
   });
 
   context('with -l python', () => {
-    test
+    // The available CLI options are calculated at import time, so we cannot mock `process.env`
+    // here to test both the env var being set and not. So instead, we only run the test when
+    // the env var is already set in the environment. The env var has intentionally not been
+    // set in `test/helpers/init.ts` since we want the tests in CI to test what the majority
+    // of customers will see. This env var is going to be very short lived (a few weeks), and
+    // all it does it change the value of the `options` array for the `--languages` flag, so is
+    // pretty safe. As such it's not worth doubling the CI matrix to test it being enabled, and
+    // instead the test has been run locally with the env var set. Once we reach beta, the env
+    // var check will be removed, and the test will always be run.
+    const testIfAlphaEnabled = 'PYTHON_FUNCTIONS_ALPHA' in process.env ? test : test.skip();
+
+    testIfAlphaEnabled
       .command(['run:function:start:local', '-l', 'python'])
       .it('should start the local runner in python mode', (ctx) => {
         expect(localRunConstructor).to.have.been.calledWith('python', {


### PR DESCRIPTION
Adds support for `--language python` to:
- `generate function`
- `run:function:start`
- `run:function:start:local`

See:
https://github.com/heroku/sf-functions-core/pull/59
https://github.com/salesforcecli/plugin-functions/pull/542
https://github.com/heroku/sf-functions-python

For now, this support is behind the environment variable `PYTHON_FUNCTIONS_ALPHA`. This env var is only temporary for the brief alpha period, and will be removed for the public beta. 

In addition, a "Python support for Salesforce Functions is experimental" console warning is shown when running the `sf generate function` command. This warning is only added here to the generate command, since the start command warning is handled in `sf-functions-core` (since otherwise there would be no way to show a warning for the start's `--language auto` mode iff using Python). The console warnings will remain for the public beta (unlike the env var), and then be removed shortly before GA.

In addition:
- the `--language` options help text now has the supported options listed alphabetically (with the exception of having `auto` be the first listed option where supported).
- the long form help text no longer duplicates the options that are automatically generated/shown
- the README has been regenerated using `npx oclif readme` (for now this doesn't include the new `--language python` options by design, since they are behind the env var).

[GUS-W-11643531](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000014tt1jYAA/view).
[GUS-W-12110485](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001EIF02YAH/view).
[GUS-W-12047682](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001COYChYAP/view).
[GUS-W-11790647](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000016vVRqYAM/view).

<!-- @W-11790647@ -->