### PR TITLE
fix: show the HTTP body for functions non HTTP-200 responses

### DIFF
--- a/src/commands/run/function.ts
+++ b/src/commands/run/function.ts
@@ -103,7 +103,7 @@ export default class Invoke extends Command {
       const error = e as AxiosError;
 
       if (error.response) {
-        this.error(new Error(`${error.response.status} ${error.response.statusText}`));
+        this.error(new Error(`${error.response.status} ${error.response.statusText}\n${error.response.data}`));
       }
 
       this.error(new Error(`${error.message}`));

--- a/test/commands/run/function.test.ts
+++ b/test/commands/run/function.test.ts
@@ -152,7 +152,10 @@ describe('sf run function', () => {
       .stderr()
       .stub(process, 'exit', () => '')
       .command(['run:function', '-l', targetUrl, '-p', userpayload])
-      .catch((error) => expect(error.message).to.contain('500 undefined'))
+      .catch((error) => {
+        expect(error.message).to.contain('500 undefined');
+        expect(error.message).to.contain('Something bad happened!');
+      })
       .finally(() => {
         sinon.assert.calledWith(stopActionSub, sinon.match('failed'));
       })


### PR DESCRIPTION
Now when using `sf run function`, if the function server responds with a non-HTTP-200 status code, the body of the response is printed too, rather than only the status code.

Before:

```
$ sf run function --function-url http://localhost:8080 --payload '{}'
Warning: No -o connected org or target-org found, context will be partially initialized
Using target-org undefined login credential to initialize context
POST http://localhost:8080... failed
    Error: 400 Bad Request
```

After:

```
$ sf run function --function-url http://localhost:8080 --payload '{}'
Warning: No -o connected org or target-org found, context will be partially initialized
Using target-org undefined login credential to initialize context
POST http://localhost:8080... failed
    Error: 400 Bad Request
    Could not parse CloudEvent: sfcontext missing required key 'apiVersion'
```

This makes debugging the functions runtime (and any issues with `plugin-functions` or `sf-functions-core`, such as https://github.com/heroku/sf-functions-core/pull/81) much easier.

This also means the `plugin-functions` behaviour now matches that of `salesforcedx-vscode`, which already outputs the response body for errors:
https://github.com/forcedotcom/salesforcedx-vscode/blob/e391707d0225de338f4f8e0e79e0a5cdd6b51f11/packages/salesforcedx-vscode-core/src/commands/functions/forceFunctionInvoke.ts#L61

[GUS-W-11725595](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE0000160dX2YAI/view).