### PR TITLE
Backport 1.13.6 release commit to `main`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.13.6](https://github.com/salesforcecli/plugin-functions/compare/v1.13.5...v1.13.6) (2022-08-29)
+
+### Bug Fixes
+
+- **deps:** update function templates ([#481](https://github.com/salesforcecli/plugin-functions/issues/481)) ([5366618](https://github.com/salesforcecli/plugin-functions/commit/5366618d38e3789a00a7ae889f0de03cf73a030d))
+
 ### [1.13.5](https://github.com/salesforcecli/plugin-functions/compare/v1.13.4...v1.13.5) (2022-08-09)
 
 ### [1.13.4](https://github.com/salesforcecli/plugin-functions/compare/v1.13.3...v1.13.4) (2022-07-20)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-functions",
   "description": "Functions plugin for the SF CLI",
-  "version": "1.13.5",
+  "version": "1.13.6",
   "author": "heroku-front-end@salesforce.com",
   "bin": {
     "functions": "./bin/run"


### PR DESCRIPTION
A cherry-pick of fd064b2b648a82fd150847f3dbb01c7e2e415620 to fix failing CI due to the previous release commit not having made it back to `main`.

See:
https://github.com/salesforcecli/plugin-functions/pull/481#issuecomment-1232788881

GUS-W-11739370.