### PR TITLE
chore: explicitly set yarn v1 as the packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
+  "packageManager": "yarn@1.22.19",
   "files": [
     "/lib",
     "/messages",


### PR DESCRIPTION
This repository currently uses Yarn v1, however since no Yarn version is defined, if I run newer `yarn` locally it auto-migrates the repository to Yarn v3's new style lockfile and configuration.

Until such time as this project is migrated officially (which likely depends on Dependabot supporting Yarn 2/3), the Yarn v1 should be specified explicitly in `package.json`.

[GUS-W-11740116](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000016IKYzYAO/view).