### PR TITLE
chore: remove unused imports

### DIFF
--- a/src/commands/env/compute/collaborator/add.ts
+++ b/src/commands/env/compute/collaborator/add.ts
@@ -6,7 +6,7 @@
  */
 import herokuColor from '@heroku-cli/color';
 import * as Heroku from '@heroku-cli/schema';
-import { Errors, Flags } from '@oclif/core';
+import { Errors } from '@oclif/core';
 import { cli } from 'cli-ux';
 import { Messages } from '@salesforce/core';
 import { FunctionsFlagBuilder } from '../../../../lib/flags';

--- a/src/commands/env/var/get.ts
+++ b/src/commands/env/var/get.ts
@@ -8,7 +8,6 @@ import herokuColor from '@heroku-cli/color';
 import * as Heroku from '@heroku-cli/schema';
 import { Messages } from '@salesforce/core';
 import { Errors } from '@oclif/core';
-import { cli } from 'cli-ux';
 import { FunctionsFlagBuilder } from '../../../lib/flags';
 
 import Command from '../../../lib/base';

--- a/src/commands/generate/function.ts
+++ b/src/commands/generate/function.ts
@@ -6,7 +6,6 @@
  */
 import herokuColor from '@heroku-cli/color';
 import { Messages } from '@salesforce/core';
-import { cli } from 'cli-ux';
 import { Errors, Flags } from '@oclif/core';
 import { generateFunction, Language } from '@hk/functions-core';
 import Command from '../../lib/base';

--- a/src/commands/login/functions/jwt.ts
+++ b/src/commands/login/functions/jwt.ts
@@ -19,21 +19,6 @@ import { fetchSfdxProject } from '../../../lib/utils';
 // It does not require a client secret, is marked as public in the database and scoped accordingly
 const PUBLIC_CLIENT_ID = '1e9cdca9-cec7-4dbf-ae84-408694b22bac';
 
-interface OAuthToken {
-  authorization: {
-    id: string;
-    scope: ['evergreen'];
-  };
-  access_token: {
-    expires_in: number;
-    id: string;
-    token: string;
-  };
-  user: {
-    id: string;
-  };
-}
-
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-functions', 'login.functions.jwt');
 

--- a/src/commands/run/function.ts
+++ b/src/commands/run/function.ts
@@ -12,7 +12,6 @@ import herokuColor from '@heroku-cli/color';
 import { AxiosResponse, AxiosError } from 'axios';
 import { ConfigAggregator, Messages } from '@salesforce/core';
 import getStdin from '../../lib/get-stdin';
-import { FunctionsFlagBuilder } from '../../lib/flags';
 import Command from '../../lib/base';
 
 Messages.importMessagesDirectory(__dirname);

--- a/src/commands/run/function/start.ts
+++ b/src/commands/run/function/start.ts
@@ -8,7 +8,6 @@
 import * as path from 'path';
 import { Messages } from '@salesforce/core';
 import { Flags } from '@oclif/core';
-import { cli } from 'cli-ux';
 
 import Local from './start/local';
 

--- a/src/commands/whoami/functions.ts
+++ b/src/commands/whoami/functions.ts
@@ -5,10 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { Flags } from '@oclif/core';
-import { cli } from 'cli-ux';
 import { dim, cyan } from 'chalk';
 import { Messages } from '@salesforce/core';
-import { FunctionsFlagBuilder } from '../../lib/flags';
 import Command from '../../lib/base';
 
 Messages.importMessagesDirectory(__dirname);


### PR DESCRIPTION
For some reason the Typescript/ESLint config in this repo doesn't detect these unused imports.

The only reason I discovered them, was that when I tried to run the main CLI repo's tests, I still had the local `plugin-functions` directory yarn linked in, so it ran those against this repository instead, which resulted in:

```
$ ./bin/dev snapshot:compare
...
(node:3457) TSError Plugin: @salesforce/plugin-functions: ⨯ Unable to compile TypeScript:
../plugin-functions/src/commands/generate/function.ts:9:1 - error TS6133: 'cli' is declared but its value is never read.

9 import { cli } from 'cli-ux';
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

module: @oclif/core@1.16.0
task: toCached
plugin: @salesforce/plugin-functions
root: /Users/emorley/src/plugin-functions
See more details with DEBUG=*
(node:3457) TSError Plugin: @salesforce/plugin-functions: ⨯ Unable to compile TypeScript:
../plugin-functions/src/commands/run/function.ts:15:1 - error TS6133: 'FunctionsFlagBuilder' is declared but its value is never read.

15 import { FunctionsFlagBuilder } from '../../lib/flags';
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

module: @oclif/core@1.16.0
task: toCached
plugin: @salesforce/plugin-functions
root: /Users/emorley/src/plugin-functions
See more details with DEBUG=*
(node:3457) TSError Plugin: @salesforce/plugin-functions: ⨯ Unable to compile TypeScript:
../plugin-functions/src/commands/whoami/functions.ts:8:1 - error TS6133: 'cli' is declared but its value is never read.

8 import { cli } from 'cli-ux';
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../plugin-functions/src/commands/whoami/functions.ts:11:1 - error TS6133: 'FunctionsFlagBuilder' is declared but its value is never read.

11 import { FunctionsFlagBuilder } from '../../lib/flags';
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

module: @oclif/core@1.16.0
task: toCached
plugin: @salesforce/plugin-functions
root: /Users/emorley/src/plugin-functions
See more details with DEBUG=*
...
(node:3457) TSError Plugin: @salesforce/plugin-functions: ⨯ Unable to compile TypeScript:
../plugin-functions/src/commands/env/var/get.ts:11:1 - error TS6133: 'cli' is declared but its value is never read.

11 import { cli } from 'cli-ux';
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

module: @oclif/core@1.16.0
task: toCached
plugin: @salesforce/plugin-functions
root: /Users/emorley/src/plugin-functions
See more details with DEBUG=*
(node:3457) TSError Plugin: @salesforce/plugin-functions: ⨯ Unable to compile TypeScript:
../plugin-functions/src/commands/login/functions/jwt.ts:22:11 - error TS6196: 'OAuthToken' is declared but never used.

22 interface OAuthToken {
             ~~~~~~~~~~

module: @oclif/core@1.16.0
task: toCached
plugin: @salesforce/plugin-functions
root: /Users/emorley/src/plugin-functions
See more details with DEBUG=*
(node:3457) TSError Plugin: @salesforce/plugin-functions: ⨯ Unable to compile TypeScript:
../plugin-functions/src/commands/run/function/start.ts:11:1 - error TS6133: 'cli' is declared but its value is never read.

11 import { cli } from 'cli-ux';
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

module: @oclif/core@1.16.0
task: toCached
plugin: @salesforce/plugin-functions
root: /Users/emorley/src/plugin-functions
See more details with DEBUG=*
(node:3457) TSError Plugin: @salesforce/plugin-functions: ⨯ Unable to compile TypeScript:
../plugin-functions/src/commands/env/compute/collaborator/add.ts:9:18 - error TS6133: 'Flags' is declared but its value is never read.

9 import { Errors, Flags } from '@oclif/core';
                   ~~~~~
```

[GUS-W-11763062](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000016aVTmYAM/view).