### PR TITLE
remove "env delete" topic desc from package.json 

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,9 +130,6 @@
               }
             }
           },
-          "delete": {
-            "description": "Commands to delete environments."
-          },
           "log": {
             "description": "Commands to stream log output for an environment."
           },


### PR DESCRIPTION
### What does this PR do?

Removes "env delete" topic description from the package.json file because there's only an "sf env delete" command in this plugin, not "env delete" as a topic.  having this in the package.json conflicts with the same package.json entry in plugin-env.  While the --help is unaffected, the CLi Command Reference generation is somehow getting confused.  Best fix is to remove the topic descr from package.json in this plugin. 

### What issues does this PR fix or reference?
@W-11855841@
