### PR TITLE
chore: switch bot user

### DIFF
--- a/.github/workflows/manualRelease.yml
+++ b/.github/workflows/manualRelease.yml
@@ -9,15 +9,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.SF_CLI_BOT_GITHUB_TOKEN }}
+          token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
       - name: Conventional Changelog Action
         id: changelog
         uses: TriPSs/conventional-changelog-action@d360fad3a42feca6462f72c97c165d60a02d4bf2
         # overriding some of the basic behaviors to just get the changelog
         with:
-          git-user-name: SF-CLI-BOT
-          git-user-email: alm-cli@salesforce.com
-          github-token: ${{ secrets.SF_CLI_BOT_GITHUB_TOKEN }}
+          git-user-name: svc-cli-bot
+          git-user-email: svc_cli_bot@salesforce.com
+          github-token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
           output-file: false
           # always do the release, even if there are no semantic commits
           skip-on-empty: false
@@ -30,7 +30,7 @@ jobs:
       - name: Create Github Release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.SF_CLI_BOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.packageVersion.outputs.prop }}
           release_name: ${{ steps.packageVersion.outputs.prop }}


### PR DESCRIPTION
### What does this PR do?
Switches the manual release github action to use a new bot user.

[@W-11955892@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000019iAa6YAE/view)