### PR TITLE
fix: bump functions-core to 0.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@heroku/eventsource": "^1.0.7",
     "@heroku/function-toml": "^0.0.3",
     "@heroku/project-descriptor": "0.0.6",
-    "@hk/functions-core": "npm:@heroku/functions-core@0.4.2",
+    "@hk/functions-core": "npm:@heroku/functions-core@0.4.3",
     "@oclif/core": "^1.6.0",
     "@salesforce/core": "^3.31.16",
     "@salesforce/plugin-org": "^1.11.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@heroku/eventsource": "^1.0.7",
     "@heroku/function-toml": "^0.0.3",
     "@heroku/project-descriptor": "0.0.6",
-    "@hk/functions-core": "npm:@heroku/functions-core@0.4.1",
+    "@hk/functions-core": "npm:@heroku/functions-core@0.4.2",
     "@oclif/core": "^1.6.0",
     "@salesforce/core": "^3.31.16",
     "@salesforce/plugin-org": "^1.11.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -453,10 +453,10 @@
     ajv-formats "^2.0.2"
     toml "^3.0.0"
 
-"@hk/functions-core@npm:@heroku/functions-core@0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@heroku/functions-core/-/functions-core-0.4.1.tgz#51f1d8458fd987d25db238fc7996cc3c8c6320bd"
-  integrity sha512-ZJGke5XM1WAVXFty56VMvimpZ+/7xwOLAtLo1m0vecD13UpkyCPJScSFpGQ4d0VwyZtKc7HjNYDb7QhOrb4O+A==
+"@hk/functions-core@npm:@heroku/functions-core@0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@heroku/functions-core/-/functions-core-0.4.2.tgz#391a4ef4672e85f8f3d1d5764206c3c3b4ec615f"
+  integrity sha512-LKcXleISKGPYqg8NZoyZSIWaaYPsAiKORlSGQ2FxbHn1mz16/xAwrv2mtSUVDvxTuPW0VxpO++rf1SBwX+wzKQ==
   dependencies:
     "@heroku-cli/color" "^1.1.14"
     "@heroku/project-descriptor" "0.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -453,10 +453,10 @@
     ajv-formats "^2.0.2"
     toml "^3.0.0"
 
-"@hk/functions-core@npm:@heroku/functions-core@0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@heroku/functions-core/-/functions-core-0.4.2.tgz#391a4ef4672e85f8f3d1d5764206c3c3b4ec615f"
-  integrity sha512-LKcXleISKGPYqg8NZoyZSIWaaYPsAiKORlSGQ2FxbHn1mz16/xAwrv2mtSUVDvxTuPW0VxpO++rf1SBwX+wzKQ==
+"@hk/functions-core@npm:@heroku/functions-core@0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@heroku/functions-core/-/functions-core-0.4.3.tgz#fb68556ab27402975cb8f9a68aae9198315ab843"
+  integrity sha512-NCurnYhaabWtPTJNZIQ8aH5lCumznn5kpAjuldj5L+aa9kEq2n/9pr2GH4y8RwOOX05MhbfLvFlQXaWOLOSFkw==
   dependencies:
     "@heroku-cli/color" "^1.1.14"
     "@heroku/project-descriptor" "0.0.6"
@@ -471,9 +471,9 @@
     mem-fs-editor "^9.5.0"
     node-fetch "^2.6.7"
     openpgp "^5.5.0"
-    semver "^7.3.7"
+    semver "^7.3.8"
     sha256-file "^1.0.0"
-    yeoman-environment "~3.10.0"
+    yeoman-environment "~3.12.1"
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
@@ -9395,10 +9395,10 @@ yeoman-environment@^3.9.1:
     textextensions "^5.12.0"
     untildify "^4.0.0"
 
-yeoman-environment@~3.10.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/yeoman-environment/-/yeoman-environment-3.10.0.tgz#d8c56571b68d16b4af8abfb950f83acc503eed77"
-  integrity sha512-sYtSxBK9daq21QjoskJTHKLQ1xEsRPURkmFV/aM8HS8ZlQVzwx57Rz1zCs8EGPhK4vqsmTE8H92Gp1jg1fT3EA==
+yeoman-environment@~3.12.1:
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/yeoman-environment/-/yeoman-environment-3.12.1.tgz#20fc0ab05d76f84c956ad03ed112e3a32e65e862"
+  integrity sha512-q5nC954SE4BEkWFXOwkifbelEZrza6z7vnXCC9bTWvfHjRiaG45eqzv/M6/u4l6PvB/KMmBPgMrACV2mBHE+PQ==
   dependencies:
     "@npmcli/arborist" "^4.0.4"
     are-we-there-yet "^2.0.0"


### PR DESCRIPTION
### What does this PR do?
Bumps `@heroku/functions-core` to `0.4.2` which includes the following changes:
- https://github.com/heroku/sf-functions-core/pull/120
- https://github.com/heroku/sf-functions-core/pull/127

### What issues does this PR fix or reference?
[@W-11854649@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000017vi0fYAA/view)