### PR TITLE
chore: remove `husky install` command from script

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "postpack": "shx rm -f oclif.manifest.json",
     "posttest": "yarn lint && yarn test:deprecation-policy",
     "prepack": "sf-prepack",
-    "prepare": "sf-install && husky install",
+    "prepare": "sf-install",
     "pretest": "sf-compile-test",
     "promote-dist-tags": "./bin/promote-dist-tags",
     "test": "sf-test",


### PR DESCRIPTION
### What does this PR do?
Removes the `husky install` command from the `prepare` script.

dev-scripts already does this in `sf-install` (which is executed when running `yarn install`).
https://github.com/forcedotcom/dev-scripts/blob/main/bin/sf-install.js#L23
https://github.com/forcedotcom/dev-scripts/blob/main/utils/husky-init.js#L15

### What issues does this PR fix or reference?
[skip-validate-pr]