### PR TITLE
feat: Make Python functions support visible without an env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,11 +482,11 @@ Create a Salesforce Function with basic scaffolding specific to a given language
 
 ```
 USAGE
-  $ sf generate function -l java|javascript|typescript [-n <value> | ]
+  $ sf generate function -l java|javascript|python|typescript [-n <value> | ]
 
 FLAGS
-  -l, --language=(java|javascript|typescript)  (required) The language in which the function is written.
-  -n, --function-name=<value>                  Function name. Must start with a capital letter.
+  -l, --language=(java|javascript|python|typescript)  (required) The language in which the function is written.
+  -n, --function-name=<value>                         Function name. Must start with a capital letter.
 
 DESCRIPTION
   Create a Salesforce Function with basic scaffolding specific to a given language.
@@ -605,13 +605,13 @@ Build and run a Salesforce Function.
 
 ```
 USAGE
-  $ sf run function start [-b <value>] [-l auto|java|javascript|typescript] [-p <value>] [-v]
+  $ sf run function start [-b <value>] [-l auto|java|javascript|python|typescript] [-p <value>] [-v]
 
 FLAGS
-  -b, --debug-port=<value>                          [default: 9229] Port for remote debugging.
-  -l, --language=(auto|java|javascript|typescript)  [default: auto] The language that the function runs in.
-  -p, --port=<value>                                [default: 8080] Port for running the function.
-  -v, --verbose                                     Output additional logs.
+  -b, --debug-port=<value>                                 [default: 9229] Port for remote debugging.
+  -l, --language=(auto|java|javascript|python|typescript)  [default: auto] The language that the function runs in.
+  -p, --port=<value>                                       [default: 8080] Port for running the function.
+  -v, --verbose                                            Output additional logs.
 
 DESCRIPTION
   Build and run a Salesforce Function.
@@ -679,12 +679,13 @@ Build and run a Salesforce Function locally.
 
 ```
 USAGE
-  $ sf run function start local [-p <value>] [-b <value>] [-l auto|java|javascript|typescript]
+  $ sf run function start local [-p <value>] [-b <value>] [-l auto|java|javascript|python|typescript]
 
 FLAGS
-  -b, --debug-port=<value>                          [default: 9229] Port to use for debugging the function.
-  -l, --language=(auto|java|javascript|typescript)  [default: auto] The language in which the function is written.
-  -p, --port=<value>                                [default: 8080] Port to bind the invoker to.
+  -b, --debug-port=<value>                                 [default: 9229] Port to use for debugging the function.
+  -l, --language=(auto|java|javascript|python|typescript)  [default: auto] The language in which the function is
+                                                           written.
+  -p, --port=<value>                                       [default: 8080] Port to bind the invoker to.
 
 DESCRIPTION
   Build and run a Salesforce Function locally.

--- a/src/commands/generate/function.ts
+++ b/src/commands/generate/function.ts
@@ -16,12 +16,7 @@ const messages = Messages.loadMessages('@salesforce/plugin-functions', 'generate
 // TODO: Make sf-functions-core export the list of language options it supports
 // for the generate function feature, and use that instead of hardcoding here.
 // See W-12120598.
-const languageOptions = [
-  'java',
-  'javascript',
-  ...('PYTHON_FUNCTIONS_ALPHA' in process.env ? ['python'] : []),
-  'typescript',
-];
+const languageOptions = ['java', 'javascript', 'python', 'typescript'];
 
 /**
  * Based on given language, create function project with specific scaffolding.

--- a/src/commands/run/function/start/local.ts
+++ b/src/commands/run/function/start/local.ts
@@ -17,13 +17,7 @@ const messages = Messages.loadMessages('@salesforce/plugin-functions', 'run.func
 // TODO: Make sf-functions-core export the list of language options it supports
 // for the local functions runners, and use that instead of hardcoding here.
 // See W-12120598.
-export const languageOptions = [
-  'auto',
-  'java',
-  'javascript',
-  ...('PYTHON_FUNCTIONS_ALPHA' in process.env ? ['python'] : []),
-  'typescript',
-];
+export const languageOptions = ['auto', 'java', 'javascript', 'python', 'typescript'];
 
 export default class Local extends Command {
   static description = messages.getMessage('summary');

--- a/test/commands/run/function/start/local.test.ts
+++ b/test/commands/run/function/start/local.test.ts
@@ -88,18 +88,7 @@ describe('sf run function start local', () => {
   });
 
   context('with -l python', () => {
-    // The available CLI options are calculated at import time, so we cannot mock `process.env`
-    // here to test both the env var being set and not. So instead, we only run the test when
-    // the env var is already set in the environment. The env var has intentionally not been
-    // set in `test/helpers/init.ts` since we want the tests in CI to test what the majority
-    // of customers will see. This env var is going to be very short lived (a few weeks), and
-    // all it does it change the value of the `options` array for the `--languages` flag, so is
-    // pretty safe. As such it's not worth doubling the CI matrix to test it being enabled, and
-    // instead the test has been run locally with the env var set. Once we reach beta, the env
-    // var check will be removed, and the test will always be run.
-    const testIfAlphaEnabled = 'PYTHON_FUNCTIONS_ALPHA' in process.env ? test : test.skip();
-
-    testIfAlphaEnabled
+    test
       .command(['run:function:start:local', '-l', 'python'])
       .it('should start the local runner in python mode', (ctx) => {
         expect(localRunConstructor).to.have.been.calledWith('python', {


### PR DESCRIPTION
Removes the requirement for the env var `PYTHON_FUNCTIONS_ALPHA` to be set, in order to use the `--language python` option to `sf generate function`, `sf run function start` and `sf run function start local`, since we are now moving to the beta phase.

The readme changes were generated using `yarn build && npx oclif readme`.

[GUS-W-12110506](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001EI3DdYAL/view).

<!-- @W-12110506@ -->