### PR TITLE
fix: exit 1 on sf run function start container

### DIFF
--- a/src/commands/run/function/start/container.ts
+++ b/src/commands/run/function/start/container.ts
@@ -9,5 +9,6 @@ import { Command } from '@oclif/core';
 export default class Container extends Command {
   async run() {
     this.log('Starting functions in container mode has been removed. Please use "sf run function start" instead.');
+    this.exit(1);
   }
 }


### PR DESCRIPTION
### What does this PR do?

exit 1 on `sf run function start container`

### What issues does this PR fix or reference?

A request from slack. To show the command did not succeed and to be a bit clearer there is a failure.

Original WI [@W-12514513@](https://gus.lightning.force.com/a07EE00001KunfCYAR)
