### PR TITLE
feat!: Remove beta Python support for Salesforce Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,11 +482,11 @@ Create a Salesforce Function with basic scaffolding specific to a given language
 
 ```
 USAGE
-  $ sf generate function -l java|javascript|python|typescript [-n <value> | ]
+  $ sf generate function -l java|javascript|typescript [-n <value> | ]
 
 FLAGS
   -l, --language=<option>      (required) The language in which the function is written.
-                               <options: java|javascript|python|typescript>
+                               <options: java|javascript|typescript>
   -n, --function-name=<value>  Function name. Must start with a capital letter.
 
 DESCRIPTION
@@ -609,12 +609,12 @@ Build and run a Salesforce Function.
 
 ```
 USAGE
-  $ sf run function start [-p <value>] [-b <value>] [-l auto|java|javascript|python|typescript] [-v]
+  $ sf run function start [-p <value>] [-b <value>] [-l auto|java|javascript|typescript] [-v]
 
 FLAGS
   -b, --debug-port=<value>  [default: 9229] Port for remote debugging.
   -l, --language=<option>   [default: auto] The language that the function runs in.
-                            <options: auto|java|javascript|python|typescript>
+                            <options: auto|java|javascript|typescript>
   -p, --port=<value>        [default: 8080] Port for running the function.
   -v, --verbose             Output additional logs.
 
@@ -649,12 +649,12 @@ Build and run a Salesforce Function locally.
 
 ```
 USAGE
-  $ sf run function start local [-p <value>] [-b <value>] [-l auto|java|javascript|python|typescript]
+  $ sf run function start local [-p <value>] [-b <value>] [-l auto|java|javascript|typescript]
 
 FLAGS
   -b, --debug-port=<value>  [default: 9229] Port to use for debugging the function.
   -l, --language=<option>   [default: auto] The language in which the function is written.
-                            <options: auto|java|javascript|python|typescript>
+                            <options: auto|java|javascript|typescript>
   -p, --port=<value>        [default: 8080] Port to bind the invoker to.
 
 DESCRIPTION

--- a/src/commands/generate/function.ts
+++ b/src/commands/generate/function.ts
@@ -16,7 +16,7 @@ const messages = Messages.loadMessages('@salesforce/plugin-functions', 'generate
 // TODO: Make sf-functions-core export the list of language options it supports
 // for the generate function feature, and use that instead of hardcoding here.
 // See W-12120598.
-const languageOptions = ['java', 'javascript', 'python', 'typescript'];
+const languageOptions = ['java', 'javascript', 'typescript'];
 
 /**
  * Based on given language, create function project with specific scaffolding.
@@ -61,10 +61,6 @@ export default class GenerateFunction extends Command {
        -n, --function-name FUNCTION-NAME  ${herokuColor.dim('Function name.')}
        See more help with --help`
       );
-    }
-
-    if (flags.language === 'python') {
-      this.warn('Python support for Salesforce Functions is experimental.');
     }
 
     if (flags.name) {

--- a/src/commands/run/function/start/local.ts
+++ b/src/commands/run/function/start/local.ts
@@ -17,7 +17,7 @@ const messages = Messages.loadMessages('@salesforce/plugin-functions', 'run.func
 // TODO: Make sf-functions-core export the list of language options it supports
 // for the local functions runners, and use that instead of hardcoding here.
 // See W-12120598.
-export const languageOptions = ['auto', 'java', 'javascript', 'python', 'typescript'];
+export const languageOptions = ['auto', 'java', 'javascript', 'typescript'];
 
 export default class Local extends Command {
   static description = messages.getMessage('summary');

--- a/test/commands/run/function/start/local.test.ts
+++ b/test/commands/run/function/start/local.test.ts
@@ -87,18 +87,6 @@ describe('sf run function start local', () => {
       });
   });
 
-  context('with -l python', () => {
-    test
-      .command(['run:function:start:local', '-l', 'python'])
-      .it('should start the local runner in python mode', (ctx) => {
-        expect(localRunConstructor).to.have.been.calledWith('python', {
-          port: 8080,
-          debugPort: 9229,
-          path: defaultFunctionPath,
-        });
-      });
-  });
-
   context('with -l typescript', () => {
     test
       .command(['run:function:start:local', '-l', 'typescript'])


### PR DESCRIPTION
Support for Salesforce Functions is being retired:
https://devcenter.heroku.com/articles/salesforce-functions-retirement
https://github.com/heroku/function-migration

Since Python support for Salesforce Functions is still in beta, support for it is being removed now, prior to that of the GA Functions languages.

See also:
https://github.com/heroku/buildpacks-python/pull/83
https://github.com/heroku/sf-functions-core/pull/278

[GUS-W-12613694](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001M8JxcYAF/view).

<!-- @W-12345678@ -->