### PR TITLE
fix(compute): add more logging around start of sf env create compute

### DIFF
--- a/test/commands/env/create/compute.test.ts
+++ b/test/commands/env/create/compute.test.ts
@@ -300,9 +300,8 @@ describe('sf env create compute', () => {
       expect(orgStub).to.have.been.calledWith({ aliasOrUsername: ORG_ALIAS });
       expect(aliasSetSpy).to.have.been.calledWith(ENVIRONMENT_ALIAS, APP_MOCK.id);
       expect(aliasWriteSpy).to.have.been.called;
-      // This is the assertion we rally care about for this test. We want to verify that everything proceeds
-      // as normal even if the first query errors because we're using the old object type
-      expect(ctx.queryStub).to.have.been.calledTwice;
+      // Latest revision should ONLY call query once, for FunctionConnection, not FunctionsConnection.
+      expect(ctx.queryStub).to.have.been.calledOnce;
     });
 
   test


### PR DESCRIPTION
### What does this PR do?

Currently unable to diagnose customer issue SEV1 that is repeating the `await pollForResult` block in `compute.ts:75`

### What issues does this PR fix or reference?

Customer Investigation:

[@W-14371436@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001dByE3YAK/view)

### Testing

after plugins:link on this branch:

```
env 'DEBUG=*' sf env create compute --connected-org=evergreen-canary-***@salesforce.com --alias=gs0wolf1
...
  sf:connection DEBUG request: {"method":"GET","url":"https://hk-fn-**orgname**gs0.my.salesforce.com/services/data/v59.0/query?q=SELECT%0A%20%20%20%20%20%20%20%20%20%20Id%2C%0A%20%20%20%20%20%20%20%20%20%20Status%2C%0A%20%20%20%20%20%20%20%20%20%20Error%0A%20%20%20%20%20%20%20%20%20%20FROM%20FunctionConnection","headers":{"content-type":"application/json","user-agent":"sfdx toolbelt:"}} +716ms
  env:create:compute query FunctionConnection records=1 millis=381 +0ms
  env:create:compute record FunctionConnection id=7WYB0000000CaeGOAS status=TrustedBiDirection error=null +0ms
  env:create:compute FunctionConnection Status=TrustedBiDirection is ready, proceeding. +0ms
  env:create:compute begin POST /sales-org-connections/00DB0000000KepTMAS/apps sfdx_project_name=gs0wolf1 ... +0ms
Creating compute environment for org ID 00DB0000000KepTMAS... done
  env:create:compute end POST millis=1531 app={"acm":false,"archived_at":null...***elided***,"web_url":null} +2s
New compute environment created with ID gs0wolf-00db0000000keptmas-064
  sf:AliasesConfig INFO Writing to config file: /***path***/.sfdx/alias.json +3s
Connecting environments... done
Your compute environment with local alias gs0wolf1 is ready.
  env:create:compute begin GET /sales-org-connections/00DB0000000KepTMAS/apps/gs0wolf1 ... +4ms
...
  sf:connection DEBUG Connection created with apiVersion 59.0 +1ms
  env:create:compute end GET millis=372 app={"acm":false,"archived_at":null,"...***elided***..."sales_org_stage":"prod"}} +372ms
  config start postrun hook +3s
  config postrun hook done +2ms
  oclif-perf Total Time: 3297.6045ms +0ms
```
