### PR TITLE
fix: add "logout" topic to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,14 @@
           }
         }
       },
+      "logout": {
+        "description": "Commands to log out of an environment.",
+        "subtopics": {
+          "functions": {
+            "description": "Commands to log out of Salesforce Functions."
+          }
+        }
+      },
       "run": {
         "description": "Commands to run a function.",
         "subtopics": {


### PR DESCRIPTION
### What does this PR do?

After removing plugin-login from the CLI, the "logout" help topic was no longer defined.  But plugin-functions still has a "logout functions" command.  So the CLI reference generator was failing.  Adding a "logout" topic to plugin-function's package.json fixes everything. 

### What issues does this PR fix or reference?

@W-14544931@
