### PR TITLE
fix: really hide container command

### DIFF
--- a/src/commands/run/function/start/container.ts
+++ b/src/commands/run/function/start/container.ts
@@ -7,7 +7,7 @@
 import { Command } from '@oclif/core';
 
 export default class Container extends Command {
-  public static hidden = false;
+  public static hidden = true;
   async run() {
     this.log('Starting functions in container mode has been removed. Please use "sf run function start" instead.');
     this.exit(1);


### PR DESCRIPTION
### What does this PR do?
follow up to https://github.com/salesforcecli/plugin-functions/pull/633
turns out we never hide it 🤦🏼‍♂️ 

If you check today, autocomplete still doesn't pick this command but that's likely because it's a JIT plugin, Juliet noticed it still shows up in the CLI reference.

### What issues does this PR fix or reference?
[skip-validate-pr]